### PR TITLE
Target SDK 32 instead of the Tiramisu preview

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkPreview = "Tiramisu"
+    compileSdk = 32
 
     defaultConfig {
         applicationId = "com.chiller3.bcr"
         minSdk = 29
-        targetSdkPreview = "Tiramisu"
+        targetSdk = 32
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -12,11 +12,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.BuildCompat
 
 object Permissions {
-    private val REQUIRED_33: Array<String> = arrayOf(Manifest.permission.POST_NOTIFICATIONS)
-
-    @BuildCompat.PrereleaseSdkCheck
-    val REQUIRED: Array<String> = if (BuildCompat.isAtLeastT()) { REQUIRED_33 } else { arrayOf() } +
-           arrayOf(Manifest.permission.RECORD_AUDIO)
+    val REQUIRED: Array<String> = arrayOf(Manifest.permission.RECORD_AUDIO)
 
     private fun isGranted(context: Context, permission: String) =
         ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -1,13 +1,34 @@
 package com.chiller3.bcr
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import com.google.android.material.color.DynamicColors
 
 class RecorderApplication : Application() {
+    companion object {
+        const val CHANNEL_ID = "persistent"
+    }
+
     override fun onCreate() {
         super.onCreate()
 
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)
+
+        createNotificationChannel()
+    }
+
+    /**
+     * Create a low priority notification channel for the persistent notification.
+     */
+    private fun createNotificationChannel() {
+        val name: CharSequence = getString(R.string.notification_channel_persistent_name)
+        val description = getString(R.string.notification_channel_persistent_desc)
+        val channel = NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_LOW)
+        channel.description = description
+
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        notificationManager.createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -1,8 +1,6 @@
 package com.chiller3.bcr
 
 import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
 import android.net.Uri
@@ -16,7 +14,6 @@ import android.util.Log
 class RecorderInCallService : InCallService(), RecorderThread.OnRecordingCompletedListener {
     companion object {
         private val TAG = RecorderInCallService::class.java.simpleName
-        private const val CHANNEL_ID = "persistent"
     }
 
     private val handler = Handler(Looper.getMainLooper())
@@ -40,11 +37,6 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
 
             handleStateChange(call)
         }
-    }
-
-    override fun onCreate() {
-        super.onCreate()
-        createNotificationChannel()
     }
 
     override fun onCallAdded(call: Call) {
@@ -115,19 +107,6 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     }
 
     /**
-     * Create a low priority notification channel for the persistent notification.
-     */
-    private fun createNotificationChannel() {
-        val name: CharSequence = getString(R.string.notification_channel_persistent_name)
-        val description = getString(R.string.notification_channel_persistent_desc)
-        val channel = NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_LOW)
-        channel.description = description
-
-        val notificationManager = getSystemService(NotificationManager::class.java)
-        notificationManager.createNotificationChannel(channel)
-    }
-
-    /**
      * Create a persistent notification for use during recording. The notification appearance is
      * fully static and in progress call recording is represented by the presence or absence of the
      * notification.
@@ -137,7 +116,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         val pendingIntent = PendingIntent.getActivity(
             this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE
         )
-        val builder = Notification.Builder(this, CHANNEL_ID)
+        val builder = Notification.Builder(this, RecorderApplication.CHANNEL_ID)
         builder.setContentTitle(getText(R.string.recording_in_progress))
         builder.setSmallIcon(R.drawable.ic_launcher_foreground)
         builder.setContentIntent(pendingIntent)

--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat


### PR DESCRIPTION
It turns out apps built with the preview SDK cannot be installed on
older stable versions of Android.

With BCR now targeting SDK 32, the creation of the notification channel
has been moved from RecorderInCallService to RecorderApplication to
ensure that Android 13 Beta devices automatically prompt for
notification permissions on the first app launch.

Once the stable SDK 33 is released, we can re-add the runtime
permissions request for POST_NOTIFICATIONS.

Fixes: #1