### PR TITLE
Add support for API 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ BCR is a simple Android call recording app for rooted devices or devices running
 
 ### Features
 
-* Supports Android 10 through 13
+* Supports Android 9 through 13
 * Records FLAC-encoded lossless audio at the device's native sample rate
 * Supports Android's Storage Access Framework (can record to SD cards, USB devices, cloud storage, etc.)
 * Quick settings toggle

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.chiller3.bcr"
-        minSdk = 29
+        minSdk = 28
         targetSdk = 32
         versionCode = 2
         versionName = "1.1"

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.core.content.ContextCompat
-import androidx.core.os.BuildCompat
 
 object Permissions {
     val REQUIRED: Array<String> = arrayOf(Manifest.permission.RECORD_AUDIO)

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -66,6 +66,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         val state = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             call.details.state
         } else {
+            @Suppress("DEPRECATION")
             call.state
         }
 


### PR DESCRIPTION
There was only one API call, `AudioFormat.getFrameSizeInBytes()`, that required at least API 29. It's trivial enough to reimplement that function manually.

Fixes: #6