### PR TITLE
RecorderThread: Add caller display name to the filename for incoming calls

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -53,6 +53,7 @@ class RecorderThread(
     } else {
         null
     }
+    private val displayName: String? = call.details.callerDisplayName
 
     init {
         Log.i(TAG, "[${id}] Created thread for call: $call")
@@ -71,6 +72,15 @@ class RecorderThread(
             if (handleUri.scheme == PhoneAccount.SCHEME_TEL) {
                 append('_')
                 append(handleUri.schemeSpecificPart)
+            }
+
+            // AOSP's SAF automatically replaces invalid characters with underscores, but just in
+            // case an OEM fork breaks that, do the replacement ourselves to prevent directory
+            // traversal attacks.
+            val name = displayName?.replace('/', '_')?.trim()
+            if (!name.isNullOrBlank()) {
+                append('_')
+                append(name)
             }
         }
 


### PR DESCRIPTION
This is based on CNAP only and does not perform lookups against the user's contacts. Note that only the initial CNAP value at the time the call becomes active is used. CNAP changes are ignored.

Issue: #3