### PR TITLE
Add git commit info to version name

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -76,7 +76,7 @@ class SettingsActivity : AppCompatActivity() {
 
             prefVersion = findPreference(Preferences.PREF_VERSION)!!
             prefVersion.onPreferenceClickListener = this
-            prefVersion.summary = BuildConfig.VERSION_NAME
+            prefVersion.summary = "${BuildConfig.VERSION_NAME} (${BuildConfig.BUILD_TYPE})"
         }
 
         override fun onResume() {


### PR DESCRIPTION
This adds the revision count since the last tag and the abbreviated git commit to the version name. These components are added only when HEAD is not already a tag.