### PR TITLE
build.gradle.kts: Only include update-binary and updater-script from the magisk directory

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -225,8 +225,11 @@ android.applicationVariants.all {
         }
 
         val magiskDir = File(projectDir, "magisk")
-        from(magiskDir) {
-            into("META-INF/com/google/android")
+
+        for (script in arrayOf("update-binary", "updater-script")) {
+            from(File(magiskDir, script)) {
+                into("META-INF/com/google/android")
+            }
         }
 
         from(File(rootDir, "LICENSE"))


### PR DESCRIPTION
By adding the whole directory, the update metadata would be included as well.