### PR TITLE
build.gradle.kts: gitVersionTriple is not serializable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,7 +237,7 @@ android.applicationVariants.all {
     }
 
     tasks.register("updateJson${capitalized}") {
-        inputs.property("gitVersionTriple", gitVersionTriple)
+        inputs.property("gitVersionTriple.first", gitVersionTriple.first)
         inputs.property("projectUrl", projectUrl)
         inputs.property("releaseMetadataBranch", releaseMetadataBranch)
         inputs.property("variant.name", variant.name)


### PR DESCRIPTION
Specifically because of the third field, which is an ObjectId instance.
Since only the first field is used by the updateJson tasks, only add
that as an input.