### PR TITLE
Add initial support for configurable codecs

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/codec/AacCodec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/AacCodec.kt
@@ -1,0 +1,36 @@
+package com.chiller3.bcr.codec
+
+import android.media.AudioFormat
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import java.io.FileDescriptor
+
+class AacCodec : Codec() {
+    override val codecParamType: CodecParamType = CodecParamType.Bitrate
+    // The codec has no hard limits, so the lower bound is ffmpeg's recommended minimum bitrate for
+    // HE-AAC: 24kbps/channel. The upper bound is twice the bitrate for audible transparency with
+    // AAC-LC: 2 * 64kbps/channel.
+    // https://trac.ffmpeg.org/wiki/Encode/AAC
+    override val codecParamRange: UIntRange = 24_000u..128_000u
+    override val codecParamDefault: UInt = 64_000u
+    // https://datatracker.ietf.org/doc/html/rfc6381#section-3.1
+    override val mimeTypeContainer: String = "audio/mp4"
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_AAC
+    override val supported: Boolean = true
+
+    override fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
+        super.getMediaFormat(audioFormat, sampleRate).apply {
+            val profile = if (codecParamValue >= 32_000u) {
+                MediaCodecInfo.CodecProfileLevel.AACObjectLC
+            } else {
+                MediaCodecInfo.CodecProfileLevel.AACObjectHE
+            }
+
+            setInteger(MediaFormat.KEY_AAC_PROFILE, profile)
+            setInteger(MediaFormat.KEY_BIT_RATE, codecParamValue.toInt() * audioFormat.channelCount)
+        }
+
+    override fun getContainer(fd: FileDescriptor): Container =
+        MediaMuxerContainer(fd, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/Codec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/Codec.kt
@@ -1,0 +1,109 @@
+package com.chiller3.bcr.codec
+
+import android.media.AudioFormat
+import android.media.MediaCodec
+import android.media.MediaCodecList
+import android.media.MediaFormat
+import android.util.Log
+import java.io.FileDescriptor
+
+sealed class Codec {
+    /** Meaning of the codec parameter value. */
+    abstract val codecParamType: CodecParamType
+
+    /** Valid range for [codecParamValue]. */
+    abstract val codecParamRange: UIntRange
+
+    /** Default codec parameter value. */
+    abstract val codecParamDefault: UInt
+
+    /**
+     * User specified codec parameter value.
+     *
+     * @throws IllegalArgumentException if the value is not in [codecParamRange]
+     */
+    var codecParamUser: UInt? = null
+        set(value) {
+            if (value == null || value in codecParamRange) {
+                field = value
+            } else {
+                throw IllegalArgumentException("Value $value not in range $codecParamRange")
+            }
+        }
+
+    /** Get the codec parameter value or the default if unset. */
+    val codecParamValue: UInt
+        get() = codecParamUser ?: codecParamDefault
+
+    /** The MIME type of the container storing the encoded audio stream. */
+    abstract val mimeTypeContainer: String
+
+    /**
+     * The MIME type of the encoded audio stream inside the container.
+     *
+     * May be the same as [mimeTypeContainer] for some codecs.
+     */
+    abstract val mimeTypeAudio: String
+
+    /** Whether the codec is supported on the current device. */
+    abstract val supported: Boolean
+
+    /**
+     * Create a [MediaFormat] representing the encoded audio with parameters matching the specified
+     * input PCM audio format.
+     */
+    open fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
+        MediaFormat().apply {
+            setString(MediaFormat.KEY_MIME, mimeTypeAudio)
+            setInteger(MediaFormat.KEY_CHANNEL_COUNT, audioFormat.channelCount)
+            setInteger(MediaFormat.KEY_SAMPLE_RATE, sampleRate)
+        }
+
+    /**
+     * Create a [MediaCodec] encoder that produces [mediaFormat] output.
+     *
+     * @param mediaFormat The [MediaFormat] instance returned by [getMediaFormat]
+     *
+     * @throws Exception if the device does not support encoding with the parameters set in
+     * [mediaFormat] or if configuring the [MediaCodec] fails.
+     */
+    fun getMediaCodec(mediaFormat: MediaFormat): MediaCodec {
+        val encoder = MediaCodecList(MediaCodecList.REGULAR_CODECS).findEncoderForFormat(mediaFormat)
+            ?: throw Exception("No suitable encoder found for $mediaFormat")
+        Log.d(TAG, "Audio encoder: $encoder")
+
+        val codec = MediaCodec.createByCodecName(encoder)
+
+        try {
+            codec.configure(mediaFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        } catch (e: Exception) {
+            codec.release()
+            throw e
+        }
+
+        return codec
+    }
+
+    /**
+     * Create a container muxer that takes encoded input and writes the muxed output to [fd].
+     *
+     * @param fd The container does not take ownership of the file descriptor
+     */
+    abstract fun getContainer(fd: FileDescriptor): Container
+
+    companion object {
+        private val TAG = Codec::class.java.simpleName
+
+        private var _all: Array<Codec>? = null
+        val all: Array<Codec>
+            get() {
+                if (_all == null) {
+                    _all = arrayOf(FlacCodec(), OpusCodec(), AacCodec())
+                }
+                return _all!!
+            }
+
+        val default: Codec
+            get() = all.first()
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/CodecParamType.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/CodecParamType.kt
@@ -1,0 +1,8 @@
+package com.chiller3.bcr.codec
+
+enum class CodecParamType {
+    /** For lossless codecs. Represents a codec-specific arbitrary integer. */
+    CompressionLevel,
+    /** For lossy codecs. Represents a bitrate *per channel* in bits per second. */
+    Bitrate,
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/Container.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/Container.kt
@@ -1,0 +1,54 @@
+package com.chiller3.bcr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import java.io.FileDescriptor
+import java.nio.ByteBuffer
+
+/**
+ * Abstract class for writing encoded samples to a container format.
+ *
+ * @param fd Output file descriptor. This class does not take ownership of it and it should not
+ * be touched outside of this class until [stop] is called and returns.
+ */
+sealed class Container(val fd: FileDescriptor) {
+    /**
+     * Start the muxer process.
+     *
+     * Must be called before [writeSamples].
+     */
+    abstract fun start()
+
+    /**
+     * Stop the muxer process.
+     *
+     * Must not be called if [start] did not complete successfully.
+     */
+    abstract fun stop()
+
+    /**
+     * Free resources used by the muxer process.
+     *
+     * Can be called in any state. If the muxer process is started, it will be stopped.
+     */
+    abstract fun release()
+
+    /**
+     * Add a track to the container with the specified format.
+     *
+     * Must not be called after the muxer process is started.
+     *
+     * @param mediaFormat Must be the instance returned by [MediaCodec.getOutputFormat]
+     */
+    abstract fun addTrack(mediaFormat: MediaFormat): Int
+
+    /**
+     * Write encoded samples to the output container.
+     *
+     * Must not be called unless the muxer process is started.
+     *
+     * @param trackIndex Must be an index returned by [addTrack]
+     */
+    abstract fun writeSamples(trackIndex: Int, byteBuffer: ByteBuffer,
+                              bufferInfo: MediaCodec.BufferInfo)
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/FlacCodec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/FlacCodec.kt
@@ -1,0 +1,25 @@
+package com.chiller3.bcr.codec
+
+import android.media.AudioFormat
+import android.media.MediaFormat
+import java.io.FileDescriptor
+
+class FlacCodec: Codec() {
+    override val codecParamType: CodecParamType = CodecParamType.CompressionLevel
+    override val codecParamRange: UIntRange = 0u..8u
+    // Devices are fast enough nowadays to use the highest compression for realtime recording
+    override var codecParamDefault: UInt = 8u
+    override var mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_FLAC
+    override var mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_FLAC
+    override var supported: Boolean = true
+
+    override fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
+        super.getMediaFormat(audioFormat, sampleRate).apply {
+            // Not relevant for lossless formats
+            setInteger(MediaFormat.KEY_BIT_RATE, 0)
+            setInteger(MediaFormat.KEY_FLAC_COMPRESSION_LEVEL, codecParamValue.toInt())
+        }
+
+    override fun getContainer(fd: FileDescriptor): Container =
+        FlacContainer(fd)
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/FlacContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/FlacContainer.kt
@@ -1,0 +1,129 @@
+@file:Suppress("OPT_IN_IS_NOT_ENABLED")
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package com.chiller3.bcr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.system.Os
+import android.system.OsConstants
+import java.io.FileDescriptor
+import java.io.IOException
+import java.nio.ByteBuffer
+
+/**
+ * Dummy FLAC container wrapper that updates the STREAMINFO duration field when complete.
+ *
+ * [MediaCodec] already produces a well-formed FLAC file, thus this class writes those samples
+ * directly to the output file.
+ */
+class FlacContainer(fd: FileDescriptor) : Container(fd) {
+    private var lastPresentationTimeUs = -1L
+    private var isStopped = true
+
+    override fun start() {
+        if (isStopped) {
+            Os.lseek(fd, 0, OsConstants.SEEK_SET)
+            Os.ftruncate(fd, 0)
+            isStopped = false
+        } else {
+            throw IllegalStateException("Called start when already started")
+        }
+    }
+
+    override fun stop() {
+        if (!isStopped) {
+            isStopped = true
+
+            if (lastPresentationTimeUs >= 0) {
+                setHeaderDuration()
+            }
+        } else {
+            throw IllegalStateException("Called stop when already stopped")
+        }
+    }
+
+    override fun release() {
+        if (!isStopped) {
+            stop()
+        }
+    }
+
+    override fun addTrack(mediaFormat: MediaFormat): Int =
+        // Not needed
+        -1
+
+    override fun writeSamples(trackIndex: Int, byteBuffer: ByteBuffer,
+                              bufferInfo: MediaCodec.BufferInfo) {
+        Os.write(fd, byteBuffer)
+
+        if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+            lastPresentationTimeUs = bufferInfo.presentationTimeUs
+        }
+    }
+
+    /**
+     * Write the frame count to the STREAMINFO metadata block of a flac file.
+     *
+     * @throws IOException If FLAC metadata does not appear to be valid or if the number of frames
+     * computed from [lastPresentationTimeUs] exceeds the bounds of a 36-bit integer
+     */
+    private fun setHeaderDuration() {
+        Os.lseek(fd, 0, OsConstants.SEEK_SET)
+
+        // Magic (4 bytes)
+        // + metadata block header (4 bytes)
+        // + streaminfo block (34 bytes)
+        val buf = UByteArray(42)
+
+        if (Os.read(fd, buf.asByteArray(), 0, buf.size) != buf.size) {
+            throw IOException("EOF reached when reading FLAC headers")
+        }
+
+        // Validate the magic
+        if (ByteBuffer.wrap(buf.asByteArray(), 0, 4) !=
+            ByteBuffer.wrap(FLAC_MAGIC.asByteArray())) {
+            throw IOException("FLAC magic not found")
+        }
+
+        // Validate that the first metadata block is STREAMINFO and has the correct size
+        if (buf[4] and 0x7fu != 0.toUByte()) {
+            throw IOException("First metadata block is not STREAMINFO")
+        }
+
+        val streamInfoSize = buf[5].toUInt().shl(16) or
+                buf[6].toUInt().shl(8) or buf[7].toUInt()
+        if (streamInfoSize < 34u) {
+            throw IOException("STREAMINFO block is too small")
+        }
+
+        // Sample rate field is a 20-bit integer at the 18th byte
+        val sampleRate = buf[18].toUInt().shl(12) or
+                buf[19].toUInt().shl(4) or
+                buf[20].toUInt().shr(4)
+
+        // This underestimates the duration by a miniscule amount because it doesn't account for the
+        // duration of the final write
+        val frames = lastPresentationTimeUs.toULong() * sampleRate / 1_000_000uL
+
+        if (frames >= 2uL.shl(36)) {
+            throw IOException("Frame count cannot be represented in FLAC: $frames")
+        }
+
+        // Total samples field is a 36-bit integer that begins 4 bits into the 21st byte
+        buf[21] = (buf[21] and 0xf0u) or (frames.shr(32) and 0xfu).toUByte()
+        buf[22] = (frames.shr(24) and 0xffu).toUByte()
+        buf[23] = (frames.shr(16) and 0xffu).toUByte()
+        buf[24] = (frames.shr(8) and 0xffu).toUByte()
+        buf[25] = (frames and 0xffu).toUByte()
+
+        Os.lseek(fd, 21, OsConstants.SEEK_SET)
+        if (Os.write(fd, buf.asByteArray(), 21, 5) != 5) {
+            throw IOException("EOF reached when writing frame count")
+        }
+    }
+
+    companion object {
+        private val FLAC_MAGIC = ubyteArrayOf(0x66u, 0x4cu, 0x61u, 0x43u) // fLaC
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/MediaMuxerContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/MediaMuxerContainer.kt
@@ -1,0 +1,39 @@
+package com.chiller3.bcr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import java.io.FileDescriptor
+import java.nio.ByteBuffer
+
+/**
+ * A thin wrapper around [MediaMuxer].
+ *
+ * @param fd Output file descriptor. This class does not take ownership of the file descriptor.
+ * @param containerFormat A valid [MediaMuxer.OutputFormat] value for the output container format.
+ */
+class MediaMuxerContainer(
+    fd: FileDescriptor,
+    containerFormat: Int,
+) : Container(fd) {
+    private val muxer = MediaMuxer(fd, containerFormat)
+
+    override fun start() {
+        muxer.start()
+    }
+
+    override fun stop() {
+        muxer.stop()
+    }
+
+    override fun release() {
+        muxer.release()
+    }
+
+    override fun addTrack(mediaFormat: MediaFormat): Int =
+        muxer.addTrack(mediaFormat)
+
+    override fun writeSamples(trackIndex: Int, byteBuffer: ByteBuffer,
+                              bufferInfo: MediaCodec.BufferInfo) =
+        muxer.writeSampleData(trackIndex, byteBuffer, bufferInfo)
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/OpusCodec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/OpusCodec.kt
@@ -1,0 +1,29 @@
+package com.chiller3.bcr.codec
+
+import android.media.AudioFormat
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.io.FileDescriptor
+
+class OpusCodec : Codec() {
+    override val codecParamType: CodecParamType = CodecParamType.Bitrate
+    override val codecParamRange: UIntRange = 6_000u..510_000u
+    // "Essentially transparent mono or stereo speech, reasonable music"
+    // https://wiki.hydrogenaud.io/index.php?title=Opus
+    override val codecParamDefault: UInt = 48_000u
+    // https://datatracker.ietf.org/doc/html/rfc7845#section-9
+    override val mimeTypeContainer: String = "audio/ogg"
+    override var mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_OPUS
+    override val supported: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+    override fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
+        super.getMediaFormat(audioFormat, sampleRate).apply {
+            setInteger(MediaFormat.KEY_BIT_RATE, codecParamValue.toInt() * audioFormat.channelCount)
+        }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    override fun getContainer(fd: FileDescriptor): Container =
+        MediaMuxerContainer(fd, MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG)
+}


### PR DESCRIPTION
This commit adds the initial framework for allowing the configuration of
output codecs. There are three codec choices available:

* FLAC: (default) lossless, compression level 0-8
* OGG/Opus: lossy, bitrate 6-510kbps, Android 10+ only
* M4A/AAC: lossy, HE-AAC bitrate 24-32kbps, AAC-LC bitrate 32-128kbps

While all three codecs are implemented, RecorderThread is currently
hardcoded to use the default. The next step is to save and load the
codec configuration from SharedPreferences and the finally add the user
interface.

Issue: #21