### PR TITLE
README.md: Remove mention of cloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ BCR is a simple Android call recording app for rooted devices or devices running
 
 * Supports Android 9 through 13
 * Records FLAC-encoded lossless audio at the device's native sample rate
-* Supports Android's Storage Access Framework (can record to SD cards, USB devices, cloud storage, etc.)
+* Supports Android's Storage Access Framework (can record to SD cards, USB devices, etc.)
 * Quick settings toggle
 * Material You dynamic theming
 * No persistent notification unless a recording is in progress


### PR DESCRIPTION
It turns out Android's Storage Access Framework doesn't support cloud
storage when using ACTION_OPEN_DOCUMENT_TREE for selecting a folder.

https://issuetracker.google.com/issues/135636079

Closes: #30