### PR TITLE
Add initial preference for output encoding format

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -207,7 +207,8 @@ class RecorderThread(
             audioRecord.startRecording()
 
             try {
-                val mediaFormat = codec.getMediaFormat(audioFormat, audioRecord.sampleRate, codecParam)
+                // audioRecord.format has the detected native sample rate
+                val mediaFormat = codec.getMediaFormat(audioRecord.format, codecParam)
                 val mediaCodec = codec.getMediaCodec(mediaFormat)
 
                 try {

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -14,6 +14,7 @@ import android.telecom.PhoneAccount
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import com.chiller3.bcr.codec.Codec
+import com.chiller3.bcr.codec.Codecs
 import com.chiller3.bcr.codec.Container
 import java.io.IOException
 import java.lang.Integer.min
@@ -43,8 +44,11 @@ class RecorderThread(
     private val listener: OnRecordingCompletedListener,
     call: Call,
 ): Thread() {
+    // Thread state
     @Volatile private var isCancelled = false
     private var captureFailed = false
+
+    // Filename
     private val handleUri: Uri = call.details.handle
     private val creationTime: Long = call.details.creationTimeMillis
     private val direction: String? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -58,11 +62,16 @@ class RecorderThread(
     }
     private val displayName: String? = call.details.callerDisplayName
 
-    // TODO
-    private val codec = Codec.default
+    // Codec
+    private val codec: Codec
+    private val codecParam: UInt?
 
     init {
         Log.i(TAG, "[${id}] Created thread for call: $call")
+
+        val savedCodec = Codecs.fromPreferences(context)
+        codec = savedCodec.first
+        codecParam = savedCodec.second
     }
 
     private fun getFilename(): String =
@@ -198,7 +207,7 @@ class RecorderThread(
             audioRecord.startRecording()
 
             try {
-                val mediaFormat = codec.getMediaFormat(audioFormat, audioRecord.sampleRate)
+                val mediaFormat = codec.getMediaFormat(audioFormat, audioRecord.sampleRate, codecParam)
                 val mediaCodec = codec.getMediaCodec(mediaFormat)
 
                 try {

--- a/app/src/main/java/com/chiller3/bcr/codec/AacCodec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/AacCodec.kt
@@ -1,35 +1,37 @@
 package com.chiller3.bcr.codec
 
-import android.media.AudioFormat
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
 import android.media.MediaMuxer
 import java.io.FileDescriptor
 
-class AacCodec : Codec() {
-    override val codecParamType: CodecParamType = CodecParamType.Bitrate
+object AacCodec : Codec() {
+    override val name: String = "M4A/AAC"
+    override val paramType: CodecParamType = CodecParamType.Bitrate
     // The codec has no hard limits, so the lower bound is ffmpeg's recommended minimum bitrate for
     // HE-AAC: 24kbps/channel. The upper bound is twice the bitrate for audible transparency with
     // AAC-LC: 2 * 64kbps/channel.
     // https://trac.ffmpeg.org/wiki/Encode/AAC
-    override val codecParamRange: UIntRange = 24_000u..128_000u
-    override val codecParamDefault: UInt = 64_000u
+    override val paramRange: UIntRange = 24_000u..128_000u
+    override val paramDefault: UInt = 64_000u
     // https://datatracker.ietf.org/doc/html/rfc6381#section-3.1
     override val mimeTypeContainer: String = "audio/mp4"
     override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_AAC
     override val supported: Boolean = true
 
-    override fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
-        super.getMediaFormat(audioFormat, sampleRate).apply {
-            val profile = if (codecParamValue >= 32_000u) {
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
+        mediaFormat.apply {
+            val profile = if (param >= 32_000u) {
                 MediaCodecInfo.CodecProfileLevel.AACObjectLC
             } else {
                 MediaCodecInfo.CodecProfileLevel.AACObjectHE
             }
+            val channelCount = getInteger(MediaFormat.KEY_CHANNEL_COUNT)
 
             setInteger(MediaFormat.KEY_AAC_PROFILE, profile)
-            setInteger(MediaFormat.KEY_BIT_RATE, codecParamValue.toInt() * audioFormat.channelCount)
+            setInteger(MediaFormat.KEY_BIT_RATE, param.toInt() * channelCount)
         }
+    }
 
     override fun getContainer(fd: FileDescriptor): Container =
         MediaMuxerContainer(fd, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)

--- a/app/src/main/java/com/chiller3/bcr/codec/Codec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/Codec.kt
@@ -37,12 +37,14 @@ sealed class Codec {
      * Create a [MediaFormat] representing the encoded audio with parameters matching the specified
      * input PCM audio format.
      *
+     * @param audioFormat [AudioFormat.getSampleRate] must not be
+     * [AudioFormat.SAMPLE_RATE_UNSPECIFIED].
      * @param param Codec-specific parameter value. Must be in the [paramRange] range. If null,
      * [paramDefault] is used.
      *
      * @throws IllegalArgumentException if [param] is outside [paramRange]
      */
-    fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int, param: UInt?): MediaFormat {
+    fun getMediaFormat(audioFormat: AudioFormat, param: UInt?): MediaFormat {
         if (param != null && param !in paramRange) {
             throw IllegalArgumentException("Parameter $param not in range $paramRange")
         }
@@ -50,7 +52,7 @@ sealed class Codec {
         val format = MediaFormat().apply {
             setString(MediaFormat.KEY_MIME, mimeTypeAudio)
             setInteger(MediaFormat.KEY_CHANNEL_COUNT, audioFormat.channelCount)
-            setInteger(MediaFormat.KEY_SAMPLE_RATE, sampleRate)
+            setInteger(MediaFormat.KEY_SAMPLE_RATE, audioFormat.sampleRate)
         }
 
         updateMediaFormat(format, param ?: paramDefault)

--- a/app/src/main/java/com/chiller3/bcr/codec/Codecs.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/Codecs.kt
@@ -1,0 +1,37 @@
+package com.chiller3.bcr.codec
+
+import android.content.Context
+import com.chiller3.bcr.Preferences
+
+object Codecs {
+    val all: Array<Codec> = arrayOf(FlacCodec, OpusCodec, AacCodec)
+    val default: Codec = all.first()
+
+    /** Find output codec by name. */
+    fun getByName(name: String): Codec? = all.find { it.name == name }
+
+    /**
+     * Get the saved codec from the preferences or fall back to the default.
+     *
+     * The parameter, if set, is clamped to the codec's allowed parameter range.
+     */
+    fun fromPreferences(context: Context): Pair<Codec, UInt?> {
+        val savedCodecName = Preferences.getCodecName(context)
+        val codec = if (savedCodecName != null) {
+            getByName(savedCodecName) ?: default
+        } else {
+            default
+        }
+
+        // Clamp to the codec's allowed parameter range in case the range is shrunk
+        val param = Preferences.getCodecParam(context, codec.name)?.coerceIn(codec.paramRange)
+
+        return Pair(codec, param)
+    }
+
+    /** Save the selected codec and its parameter to the preferences. */
+    fun saveToPreferences(context: Context, codec: Codec, param: UInt?) {
+        Preferences.setCodecName(context, codec.name)
+        Preferences.setCodecParam(context, codec.name, param)
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/codec/FlacCodec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/FlacCodec.kt
@@ -1,24 +1,25 @@
 package com.chiller3.bcr.codec
 
-import android.media.AudioFormat
 import android.media.MediaFormat
 import java.io.FileDescriptor
 
-class FlacCodec: Codec() {
-    override val codecParamType: CodecParamType = CodecParamType.CompressionLevel
-    override val codecParamRange: UIntRange = 0u..8u
+object FlacCodec: Codec() {
+    override val name: String = "FLAC"
+    override val paramType: CodecParamType = CodecParamType.CompressionLevel
+    override val paramRange: UIntRange = 0u..8u
     // Devices are fast enough nowadays to use the highest compression for realtime recording
-    override var codecParamDefault: UInt = 8u
-    override var mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_FLAC
-    override var mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_FLAC
-    override var supported: Boolean = true
+    override val paramDefault: UInt = 8u
+    override val mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_FLAC
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_FLAC
+    override val supported: Boolean = true
 
-    override fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
-        super.getMediaFormat(audioFormat, sampleRate).apply {
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
+        mediaFormat.apply {
             // Not relevant for lossless formats
             setInteger(MediaFormat.KEY_BIT_RATE, 0)
-            setInteger(MediaFormat.KEY_FLAC_COMPRESSION_LEVEL, codecParamValue.toInt())
+            setInteger(MediaFormat.KEY_FLAC_COMPRESSION_LEVEL, param.toInt())
         }
+    }
 
     override fun getContainer(fd: FileDescriptor): Container =
         FlacContainer(fd)

--- a/app/src/main/java/com/chiller3/bcr/codec/OpusCodec.kt
+++ b/app/src/main/java/com/chiller3/bcr/codec/OpusCodec.kt
@@ -1,27 +1,29 @@
 package com.chiller3.bcr.codec
 
-import android.media.AudioFormat
 import android.media.MediaFormat
 import android.media.MediaMuxer
 import android.os.Build
 import androidx.annotation.RequiresApi
 import java.io.FileDescriptor
 
-class OpusCodec : Codec() {
-    override val codecParamType: CodecParamType = CodecParamType.Bitrate
-    override val codecParamRange: UIntRange = 6_000u..510_000u
+object OpusCodec : Codec() {
+    override val name: String = "OGG/Opus"
+    override val paramType: CodecParamType = CodecParamType.Bitrate
+    override val paramRange: UIntRange = 6_000u..510_000u
     // "Essentially transparent mono or stereo speech, reasonable music"
     // https://wiki.hydrogenaud.io/index.php?title=Opus
-    override val codecParamDefault: UInt = 48_000u
+    override val paramDefault: UInt = 48_000u
     // https://datatracker.ietf.org/doc/html/rfc7845#section-9
     override val mimeTypeContainer: String = "audio/ogg"
-    override var mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_OPUS
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_OPUS
     override val supported: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 
-    override fun getMediaFormat(audioFormat: AudioFormat, sampleRate: Int): MediaFormat =
-        super.getMediaFormat(audioFormat, sampleRate).apply {
-            setInteger(MediaFormat.KEY_BIT_RATE, codecParamValue.toInt() * audioFormat.channelCount)
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
+        mediaFormat.apply {
+            val channelCount = getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+            setInteger(MediaFormat.KEY_BIT_RATE, param.toInt() * channelCount)
         }
+    }
 
     @RequiresApi(Build.VERSION_CODES.Q)
     override fun getContainer(fd: FileDescriptor): Container =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <string name="pref_output_dir_name">Output directory</string>
     <string name="pref_output_dir_desc">Pick a directory to store recordings. Long press to reset to the default directory.</string>
 
+    <string name="pref_output_format_name">Output format</string>
+    <string name="pref_output_format_desc">Select an encoding format for the recordings. Long press to reset all encoder settings to the default.</string>
+
     <string name="pref_inhibit_batt_opt_name">Disable battery optimization</string>
     <string name="pref_inhibit_batt_opt_desc">Reduces the chance of the app being killed by the system.</string>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -17,6 +17,14 @@
             app:summary="@string/pref_output_dir_desc"
             app:iconSpaceReserved="false" />
 
+        <com.chiller3.bcr.LongClickablePreference
+            app:dependency="call_recording"
+            app:key="output_format"
+            app:persistent="false"
+            app:title="@string/pref_output_format_name"
+            app:summary="@string/pref_output_format_desc"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             app:key="inhibit_batt_opt"
             app:title="@string/pref_inhibit_batt_opt_name"


### PR DESCRIPTION
This PR implements the initial preference UI for the output format as well as having `RecorderThread` use the selected codec (and codec parameter) for encoding.

Codec configuration is not yet possible. That will be implemented in a future PR.

Issue: #21 