### PR TITLE
Redact sensitive information from logcat

### DIFF
--- a/app/magisk/updates/release/changelog.txt
+++ b/app/magisk/updates/release/changelog.txt
@@ -2,6 +2,7 @@
 
 * Optionally add contact name to output filename if Contacts permission is granted (Android 11+) (Issue: #28, PR: #42, @chenxiaolong)
 * Add Spanish translation (PR: #41, @nmayorga092)
+* Redact sensitive information from logcat logs (PR: #43, @chenxiaolong)
 
 ### Version 1.4
 

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -153,14 +153,14 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     }
 
     override fun onRecordingCompleted(thread: RecorderThread, uri: Uri) {
-        Log.i(TAG, "Recording completed: ${thread.id}: $uri")
+        Log.i(TAG, "Recording completed: ${thread.id}: ${thread.redact(uri.toString())}")
         handler.post {
             onThreadExited()
         }
     }
 
     override fun onRecordingFailed(thread: RecorderThread, uri: Uri?) {
-        Log.w(TAG, "Recording failed: ${thread.id}: $uri")
+        Log.w(TAG, "Recording failed: ${thread.id}: ${thread.redact(uri.toString())}")
         handler.post {
             onThreadExited()
         }


### PR DESCRIPTION
This commit updates BCR's own logging to redact:

* Phone number
* CNAP/Caller ID
* Contact name

from log messages. Note that this is not foolproof because Android
itself (eg. MediaProvider) will log the full filename.