### PR TITLE
Enable minification of release builds without obfuscation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,8 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
 
             signingConfig = signingConfigs.getByName("release")

--- a/app/magisk/updates/release/changelog.txt
+++ b/app/magisk/updates/release/changelog.txt
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Enable minification (without obfuscation) to shrink the download size by ~64% (PR: #45, @chenxiaolong)
+
 ### Version 1.5
 
 * Optionally add contact name to output filename if Contacts permission is granted (Android 11+) (Issue: #28, PR: #42, @chenxiaolong)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,8 +14,12 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Disable obfuscation completely for BCR. As an open source project,
+# shrinking is the only goal of minification.
+-dontobfuscate


### PR DESCRIPTION
Obfuscation makes nearly no difference in size for this project. No
reason to make life harder for folks who want to inspect the compiled
binaries.