### PR TITLE
Rework buffering mechanism for recording

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/format/AacFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/AacFormat.kt
@@ -1,6 +1,5 @@
 package com.chiller3.bcr.format
 
-import android.media.AudioFormat
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
 import android.media.MediaMuxer
@@ -24,11 +23,7 @@ object AacFormat : Format() {
     override val passthrough: Boolean = false
     override val supported: Boolean = true
 
-    override fun updateMediaFormat(
-        mediaFormat: MediaFormat,
-        audioFormat: AudioFormat,
-        param: UInt,
-    ) {
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {
             val profile = if (param >= 32_000u) {
                 MediaCodecInfo.CodecProfileLevel.AACObjectLC

--- a/app/src/main/java/com/chiller3/bcr/format/Encoder.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/Encoder.kt
@@ -1,0 +1,48 @@
+package com.chiller3.bcr.format
+
+import android.media.MediaFormat
+import java.nio.ByteBuffer
+
+abstract class Encoder(
+    mediaFormat: MediaFormat,
+) {
+    protected val frameSize = mediaFormat.getInteger(Format.KEY_X_FRAME_SIZE_IN_BYTES)
+    private val sampleRate = mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+
+    /** Number of frames encoded so far. */
+    protected var numFrames = 0L
+
+    /** Presentation timestamp given [numFrames] already being encoded */
+    protected val timestampUs
+        get() = numFrames * 1_000_000L / sampleRate
+
+    /**
+     * Start the encoder process.
+     *
+     * Can only be called if the encoder process is not already started.
+     */
+    abstract fun start()
+
+    /**
+     * Stop the encoder process.
+     *
+     * Can only be called if the encoder process is started.
+     */
+    abstract fun stop()
+
+    /**
+     * Release resources used by the encoder process.
+     *
+     * If the encoder process is not already stopped, then it will be stopped.
+     */
+    abstract fun release()
+
+    /**
+     * Submit a buffer to be encoded.
+     *
+     * @param buffer Must be in the PCM format expected by the encoder and [ByteBuffer.position]
+     * and [ByteBuffer.limit] must correctly represent the bounds of the data.
+     * @param isEof No more data can be submitted after this method is called once with EOF == true.
+     */
+    abstract fun encode(buffer: ByteBuffer, isEof: Boolean)
+}

--- a/app/src/main/java/com/chiller3/bcr/format/FlacFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/FlacFormat.kt
@@ -1,6 +1,5 @@
 package com.chiller3.bcr.format
 
-import android.media.AudioFormat
 import android.media.MediaFormat
 import java.io.FileDescriptor
 
@@ -18,11 +17,7 @@ object FlacFormat : Format() {
     override val passthrough: Boolean = false
     override val supported: Boolean = true
 
-    override fun updateMediaFormat(
-        mediaFormat: MediaFormat,
-        audioFormat: AudioFormat,
-        param: UInt,
-    ) {
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {
             // Not relevant for lossless formats
             setInteger(MediaFormat.KEY_BIT_RATE, 0)

--- a/app/src/main/java/com/chiller3/bcr/format/MediaCodecEncoder.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/MediaCodecEncoder.kt
@@ -1,0 +1,128 @@
+package com.chiller3.bcr.format
+
+import android.media.MediaCodec
+import android.media.MediaCodecList
+import android.media.MediaFormat
+import android.util.Log
+import java.lang.Integer.min
+import java.nio.ByteBuffer
+
+/**
+ * Create a [MediaCodec]-based encoder for the specified format.
+ *
+ * @param mediaFormat The [MediaFormat] instance returned by [Format.getMediaFormat].
+ * @param container The container for storing the encoded audio stream.
+ *
+ * @throws Exception if the device does not support encoding with the parameters set in the format
+ * or if configuring the [MediaCodec] fails.
+ */
+class MediaCodecEncoder(
+    mediaFormat: MediaFormat,
+    private val container: Container,
+) : Encoder(mediaFormat) {
+    private val codec = createCodec(mediaFormat)
+    private val bufferInfo = MediaCodec.BufferInfo()
+    private var trackIndex = -1
+
+    override fun start() =
+        codec.start()
+
+    override fun stop() =
+        codec.stop()
+
+    override fun release() =
+        codec.release()
+
+    override fun encode(buffer: ByteBuffer, isEof: Boolean) {
+        while (true) {
+            var waitForever = false
+
+            val inputBufferId = codec.dequeueInputBuffer(TIMEOUT)
+            if (inputBufferId >= 0) {
+                val inputBuffer = codec.getInputBuffer(inputBufferId)!!
+                // Maximum non-overflowing buffer size that is a multiple of the frame size
+                val toCopy = min(buffer.remaining(), inputBuffer.remaining()) / frameSize * frameSize
+
+                // Temporarily change buffer limit to avoid overflow
+                val oldLimit = buffer.limit()
+                buffer.limit(buffer.position() + toCopy)
+                inputBuffer.put(buffer)
+                buffer.limit(oldLimit)
+
+                // Submit EOF if the entire buffer has been consumed
+                val flags = if (isEof && !buffer.hasRemaining()) {
+                    Log.d(TAG, "On final buffer; submitting EOF")
+                    waitForever = true
+                    MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                } else {
+                    0
+                }
+
+                codec.queueInputBuffer(inputBufferId, 0, toCopy, timestampUs, flags)
+
+                numFrames += toCopy / frameSize
+            } else {
+                Log.w(TAG, "Unexpected input buffer dequeue error: $inputBufferId")
+            }
+
+            flush(waitForever)
+
+            if (!buffer.hasRemaining()) {
+                break
+            }
+        }
+    }
+
+    /** Flush [MediaCodec]'s pending encoded data to [container]. */
+    private fun flush(waitForever: Boolean) {
+        while (true) {
+            val timeout = if (waitForever) { -1 } else { TIMEOUT }
+            val outputBufferId = codec.dequeueOutputBuffer(bufferInfo, timeout)
+            if (outputBufferId >= 0) {
+                val buffer = codec.getOutputBuffer(outputBufferId)!!
+
+                container.writeSamples(trackIndex, buffer, bufferInfo)
+
+                codec.releaseOutputBuffer(outputBufferId, false)
+
+                if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                    Log.d(TAG, "Received EOF; fully flushed")
+                    // Output has been fully written
+                    break
+                }
+            } else if (outputBufferId == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                val outputFormat = codec.outputFormat
+                Log.d(TAG, "Output format changed to: $outputFormat")
+                trackIndex = container.addTrack(outputFormat)
+                container.start()
+            } else if (outputBufferId == MediaCodec.INFO_TRY_AGAIN_LATER) {
+                break
+            } else {
+                Log.w(TAG, "Unexpected output buffer dequeue error: $outputBufferId")
+                break
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = MediaCodecEncoder::class.java.simpleName
+        private const val TIMEOUT = 500L
+
+        fun createCodec(mediaFormat: MediaFormat): MediaCodec {
+            val encoder = MediaCodecList(MediaCodecList.REGULAR_CODECS).findEncoderForFormat(mediaFormat)
+                ?: throw Exception("No suitable encoder found for $mediaFormat")
+            Log.d(TAG, "Audio encoder: $encoder")
+
+            val codec = MediaCodec.createByCodecName(encoder)
+
+            try {
+                codec.configure(mediaFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+            } catch (e: Exception) {
+                codec.release()
+                throw e
+            }
+
+            return codec
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/format/MediaMuxerContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/MediaMuxerContainer.kt
@@ -18,17 +18,14 @@ class MediaMuxerContainer(
 ) : Container() {
     private val muxer = MediaMuxer(fd, containerFormat)
 
-    override fun start() {
+    override fun start() =
         muxer.start()
-    }
 
-    override fun stop() {
+    override fun stop() =
         muxer.stop()
-    }
 
-    override fun release() {
+    override fun release() =
         muxer.release()
-    }
 
     override fun addTrack(mediaFormat: MediaFormat): Int =
         muxer.addTrack(mediaFormat)

--- a/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
@@ -1,6 +1,5 @@
 package com.chiller3.bcr.format
 
-import android.media.AudioFormat
 import android.media.MediaFormat
 import android.media.MediaMuxer
 import android.os.Build
@@ -23,11 +22,7 @@ object OpusFormat : Format() {
     override val passthrough: Boolean = false
     override val supported: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 
-    override fun updateMediaFormat(
-        mediaFormat: MediaFormat,
-        audioFormat: AudioFormat,
-        param: UInt,
-    ) {
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {
             val channelCount = getInteger(MediaFormat.KEY_CHANNEL_COUNT)
             setInteger(MediaFormat.KEY_BIT_RATE, param.toInt() * channelCount)

--- a/app/src/main/java/com/chiller3/bcr/format/PassthroughEncoder.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/PassthroughEncoder.kt
@@ -1,0 +1,66 @@
+package com.chiller3.bcr.format
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import java.lang.IllegalStateException
+import java.nio.ByteBuffer
+
+/**
+ * Create a passthrough encoder for the specified format.
+ *
+ * @param mediaFormat The [MediaFormat] instance returned by [Format.getMediaFormat].
+ * @param container The container for storing the raw PCM audio stream.
+ */
+class PassthroughEncoder(
+    private val mediaFormat: MediaFormat,
+    private val container: Container,
+) : Encoder(mediaFormat) {
+    private var isStarted = false
+    private val bufferInfo = MediaCodec.BufferInfo()
+    private var trackIndex = -1
+
+    override fun start() {
+        if (isStarted) {
+            throw IllegalStateException("Encoder is already started")
+        }
+
+        isStarted = true
+        trackIndex = container.addTrack(mediaFormat)
+        container.start()
+    }
+
+    override fun stop() {
+        if (!isStarted) {
+            throw IllegalStateException("Encoder is not started")
+        }
+
+        isStarted = false
+    }
+
+    override fun release() {
+        if (isStarted) {
+            stop()
+        }
+    }
+
+    override fun encode(buffer: ByteBuffer, isEof: Boolean) {
+        if (!isStarted) {
+            throw IllegalStateException("Encoder is not started")
+        }
+
+        val frames = buffer.remaining() / frameSize
+
+        bufferInfo.offset = buffer.position()
+        bufferInfo.size = buffer.limit()
+        bufferInfo.presentationTimeUs = timestampUs
+        bufferInfo.flags = if (isEof) {
+            MediaCodec.BUFFER_FLAG_END_OF_STREAM
+        } else {
+            0
+        }
+
+        container.writeSamples(trackIndex, buffer, bufferInfo)
+
+        numFrames += frames
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/format/WaveFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/WaveFormat.kt
@@ -1,13 +1,9 @@
 package com.chiller3.bcr.format
 
-import android.media.AudioFormat
 import android.media.MediaFormat
-import com.chiller3.bcr.frameSizeInBytesCompat
 import java.io.FileDescriptor
 
 object WaveFormat : Format() {
-    const val KEY_X_FRAME_SIZE_IN_BYTES = "x-frame-size-in-bytes"
-
     override val name: String = "WAV/PCM"
     override val paramInfo: FormatParamInfo = NoParamInfo
     // Should be "audio/vnd.wave" [1], but Android only recognizes "audio/x-wav" [2] for the
@@ -19,12 +15,8 @@ object WaveFormat : Format() {
     override val passthrough: Boolean = true
     override val supported: Boolean = true
 
-    override fun updateMediaFormat(
-        mediaFormat: MediaFormat,
-        audioFormat: AudioFormat,
-        param: UInt,
-    ) {
-        mediaFormat.setInteger(KEY_X_FRAME_SIZE_IN_BYTES, audioFormat.frameSizeInBytesCompat)
+    override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
+        // Not needed
     }
 
     override fun getContainer(fd: FileDescriptor): Container =


### PR DESCRIPTION
Previously, for passthrough recording, AudioRecord would record into a
100ms sized buffer (at the specified sample rate). For encoded
recording, it would record directly into MediaCodec's buffers, which may
or may not be sized appropriately.

This commit unifies the buffering scheme for both types of recording to
use a buffer twice the size of `AudioRecord.getMinBufferSize`. It also
introduces the `Encoder` abstraction to allow dealing with passthrough
and MediaCodec the same way.