### PR TITLE
Container: Change to an interface

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/format/Container.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/Container.kt
@@ -7,27 +7,27 @@ import java.nio.ByteBuffer
 /**
  * Abstract class for writing encoded samples to a container format.
  */
-sealed class Container {
+interface Container {
     /**
      * Start the muxer process.
      *
      * Must be called before [writeSamples].
      */
-    abstract fun start()
+    fun start()
 
     /**
      * Stop the muxer process.
      *
      * Must not be called if [start] did not complete successfully.
      */
-    abstract fun stop()
+    fun stop()
 
     /**
      * Free resources used by the muxer process.
      *
      * Can be called in any state. If the muxer process is started, it will be stopped.
      */
-    abstract fun release()
+    fun release()
 
     /**
      * Add a track to the container with the specified format.
@@ -36,7 +36,7 @@ sealed class Container {
      *
      * @param mediaFormat Must be the instance returned by [MediaCodec.getOutputFormat]
      */
-    abstract fun addTrack(mediaFormat: MediaFormat): Int
+    fun addTrack(mediaFormat: MediaFormat): Int
 
     /**
      * Write encoded samples to the output container.
@@ -45,6 +45,5 @@ sealed class Container {
      *
      * @param trackIndex Must be an index returned by [addTrack]
      */
-    abstract fun writeSamples(trackIndex: Int, byteBuffer: ByteBuffer,
-                              bufferInfo: MediaCodec.BufferInfo)
+    fun writeSamples(trackIndex: Int, byteBuffer: ByteBuffer, bufferInfo: MediaCodec.BufferInfo)
 }

--- a/app/src/main/java/com/chiller3/bcr/format/FlacContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/FlacContainer.kt
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
  * @param fd Output file descriptor. This class does not take ownership of it and it should not
  * be touched outside of this class until [stop] is called and returns.
  */
-class FlacContainer(private val fd: FileDescriptor) : Container() {
+class FlacContainer(private val fd: FileDescriptor) : Container {
     private var isStarted = false
     private var lastPresentationTimeUs = -1L
     private var track = -1

--- a/app/src/main/java/com/chiller3/bcr/format/MediaMuxerContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/MediaMuxerContainer.kt
@@ -15,7 +15,7 @@ import java.nio.ByteBuffer
 class MediaMuxerContainer(
     fd: FileDescriptor,
     containerFormat: Int,
-) : Container() {
+) : Container {
     private val muxer = MediaMuxer(fd, containerFormat)
 
     override fun start() =

--- a/app/src/main/java/com/chiller3/bcr/format/WaveContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/WaveContainer.kt
@@ -11,7 +11,7 @@ import java.io.FileDescriptor
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-class WaveContainer(private val fd: FileDescriptor) : Container() {
+class WaveContainer(private val fd: FileDescriptor) : Container {
     private var isStarted = false
     private var track = -1
     private var frameSize = 0


### PR DESCRIPTION
There's no internal state, so an abstract class is not needed.