### PR TITLE
Significantly increase AudioRecord's internal buffer size

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/FormatBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FormatBottomSheetFragment.kt
@@ -52,7 +52,6 @@ class FormatBottomSheetFragment : BottomSheetDialogFragment(),
 
         binding.nameGroup.setOnCheckedStateChangeListener(this)
 
-        addSampleRateChip(inflater, null)
         for (sampleRate in SampleRates.all) {
             addSampleRateChip(inflater, sampleRate)
         }
@@ -82,12 +81,12 @@ class FormatBottomSheetFragment : BottomSheetDialogFragment(),
         formatToChipId[format] = id
     }
 
-    private fun addSampleRateChip(inflater: LayoutInflater, sampleRate: UInt?) {
+    private fun addSampleRateChip(inflater: LayoutInflater, sampleRate: UInt) {
         val chipBinding = FormatBottomSheetChipBinding.inflate(
             inflater, binding.sampleRateGroup, false)
         val id = View.generateViewId()
         chipBinding.root.id = id
-        chipBinding.root.text = SampleRates.format(requireContext(), sampleRate)
+        chipBinding.root.text = SampleRates.format(sampleRate)
         chipBinding.root.layoutDirection = View.LAYOUT_DIRECTION_LOCALE
         binding.sampleRateGroup.addView(chipBinding.root)
         chipIdToSampleRate[id] = sampleRate

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -298,6 +298,8 @@ class RecorderThread(
                 audioRecord.format.frameSizeInBytesCompat
         Log.d(tag, "AudioRecord initial buffer size: $initialBufSize")
 
+        Log.d(tag, "AudioRecord format: ${audioRecord.format}")
+
         // Where's my RAII? :(
         try {
             audioRecord.startRecording()

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -237,8 +237,10 @@ class RecorderThread(
         if (userUri != null) {
             try {
                 // Only returns null on API <21
-                val userDir = DocumentFile.fromTreeUri(context, userUri)
-                return openOutputFileInDir(userDir!!, name, mimeType)
+                val userDir = DocumentFile.fromTreeUri(context, userUri)!!
+                Log.d(tag, "Using user-specified directory: ${userDir.uri}")
+
+                return openOutputFileInDir(userDir, name, mimeType)
             } catch (e: Exception) {
                 Log.e(tag, "Failed to open file in user-specified directory: $userUri", e)
             }

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -390,7 +390,7 @@ class RecorderThread(
 
             val totalElapsed = System.nanoTime() - begin
             if (encodeElapsed > bufferNs) {
-                Log.w(tag, "Encoding took too long: " +
+                Log.w(tag, "${encoder.javaClass.simpleName} took too long: " +
                         "timestamp=${numFrames.toDouble() / audioRecord.sampleRate}s, " +
                         "buffer=${bufferNs / 1_000_000.0}ms, " +
                         "total=${totalElapsed / 1_000_000.0}ms, " +

--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -119,7 +119,7 @@ class SettingsActivity : AppCompatActivity() {
                 is RangedParamInfo -> "${info.format(formatParam)}, "
                 NoParamInfo -> ""
             }
-            val sampleRate = SampleRates.format(context, SampleRates.fromPreferences(context))
+            val sampleRate = SampleRates.format(SampleRates.fromPreferences(context))
 
             prefOutputFormat.summary = "${summary}\n\n${format.name} (${prefix}${sampleRate})"
         }

--- a/app/src/main/java/com/chiller3/bcr/format/SampleRates.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/SampleRates.kt
@@ -22,26 +22,23 @@ object SampleRates {
         24_000u,
         48_000u,
     )
+    val default = all.last()
 
     /**
      * Get the saved sample rate from the preferences.
      *
-     * If the saved sample rate is no longer valid, then null is returned.
+     * If the saved sample rate is no longer valid or no sample rate is selected, then [default]
+     * is returned.
      */
-    fun fromPreferences(context: Context): UInt? {
+    fun fromPreferences(context: Context): UInt {
         val savedSampleRate = Preferences.getSampleRate(context)
 
         if (savedSampleRate != null && all.contains(savedSampleRate)) {
             return savedSampleRate
         }
 
-        return null
+        return default
     }
 
-    fun format(context: Context, sampleRate: UInt?): String =
-        if (sampleRate == null) {
-            context.getString(R.string.bottom_sheet_sample_rate_native)
-        } else {
-            "$sampleRate Hz"
-        }
+    fun format(sampleRate: UInt): String = "$sampleRate Hz"
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -27,7 +27,6 @@
     <string name="bottom_sheet_compression_level">Nivel de compresión</string>
     <string name="bottom_sheet_bitrate">Bitrate</string>
     <string name="bottom_sheet_sample_rate">Frecuencia de muestreo</string>
-    <string name="bottom_sheet_sample_rate_native">Frecuencia de muestreo nativa</string>
     <string name="bottom_sheet_reset">Restablecer los valores predeterminados</string>
 
     <!-- Notifications -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -27,7 +27,6 @@
     <string name="bottom_sheet_compression_level">Sıkıştırma seviyesi</string>
     <string name="bottom_sheet_bitrate">Bitrate</string>
     <string name="bottom_sheet_sample_rate">Örnekleme hızı</string>
-    <string name="bottom_sheet_sample_rate_native">Varsayılana örnekleme hızı</string>
     <string name="bottom_sheet_reset">Varsayılana döndür</string>
     
     <!-- Notifications -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="bottom_sheet_compression_level">Compression level</string>
     <string name="bottom_sheet_bitrate">Bitrate</string>
     <string name="bottom_sheet_sample_rate">Sample rate</string>
-    <string name="bottom_sheet_sample_rate_native">Native sample rate</string>
     <string name="bottom_sheet_reset">Reset to defaults</string>
 
     <!-- Notifications -->


### PR DESCRIPTION
This helps absorb some of the impact of encoding slowdowns at the expense of latency, which doesn't matter for recording purposes.

This also necessitates the removal of the native sample rate option because it would require initializing AudioRecord twice: the first time to detect the sample rate and the second time to set the desired sample-rate-dependent buffer size. It's better to explicitly specify a sample rate anyway because the native sample rate may not be compatible with all codecs (eg. Opus does not support 44100Hz).