### PR TITLE
RecorderThread: Make AudioRecord internal buffer less excessively large

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -358,8 +358,8 @@ class RecorderThread(
             CHANNEL_CONFIG,
             ENCODING,
             // On some devices, MediaCodec occasionally has sudden spikes in processing time, so use
-            // a large internal buffer to reduce the chance of overrun on the recording side.
-            minBufSize * 20,
+            // a larger internal buffer to reduce the chance of overrun on the recording side.
+            minBufSize * 6,
         )
         val initialBufSize = audioRecord.bufferSizeInFrames *
                 audioRecord.format.frameSizeInBytesCompat


### PR DESCRIPTION
When the call ends, everything still remaining in AudioRecord's internal
buffer is lost because there's no way to read the remaining bytes after
recording is stopped. With 20x the buffer size on eg. a device with a
1920 byte minimum buffer size and a sample rate of 8000 Hz, this may
cause 2.4 seconds of audio at the end of the call to be lost.

This commit should not have a negative effect since the large buffer
size was meant to address buffer overruns and the root cause of that
problem was fixed in #72.