### PR TITLE
SettingsActivity: Prompt for optional contacts permission on first enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
 
 4. Enable call recording and pick an output directory. If no output directory is selected or if the output directory is no longer accessible, then recordings will be saved to `/sdcard/Android/data/com.chiller3.bcr/files`.
 
+    When enabling call recording the first time, BCR will prompt for microphone, notification (Android 13+), and contacts permissions. Microphone and notification permissions are required for BCR to be able to record phone calls in the background.
+
+    The contacts permission is optional, but if allowed, contact names will be added to the recordings' filenames. BCR never sends contact information anywhere. In fact, it does not even have the `INTERNET` permission. However, other third party applications may be able to see the contact names if they can access the output directory.
+
 5. To install future updates, there are a couple methods:
 
     * If installed via Magisk, the module can be updated right from Magisk Manager's modules tab. Flashing the new version in Magisk manually also works just as well.

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -20,6 +20,7 @@ object Permissions {
         }
 
     val REQUIRED: Array<String> = arrayOf(Manifest.permission.RECORD_AUDIO) + NOTIFICATION
+    val OPTIONAL: Array<String> = arrayOf(Manifest.permission.READ_CONTACTS)
 
     private fun isGranted(context: Context, permission: String) =
         ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -42,7 +42,8 @@ class SettingsActivity : AppCompatActivity() {
 
         private val requestPermissionRequired =
             registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { granted ->
-                if (granted.all { it.value }) {
+                // Call recording can still be enabled if optional permissions were not granted
+                if (granted.all { it.key !in Permissions.REQUIRED || it.value }) {
                     prefCallRecording.isChecked = true
                 } else {
                     startActivity(Permissions.getAppInfoIntent(requireContext()))
@@ -174,7 +175,8 @@ class SettingsActivity : AppCompatActivity() {
                 prefCallRecording -> if (Permissions.haveRequired(context)) {
                     return true
                 } else {
-                    requestPermissionRequired.launch(Permissions.REQUIRED)
+                    // Ask for optional permissions the first time only
+                    requestPermissionRequired.launch(Permissions.REQUIRED + Permissions.OPTIONAL)
                 }
                 // This is only reachable if battery optimization is not already inhibited
                 prefInhibitBatteryOpt -> requestInhibitBatteryOpt.launch(


### PR DESCRIPTION
The contacts permission is used to add the contact name to the output
filenames. The permission prompt will only be shown the first time call
recording is enabled. If the user chooses to not allow the permission,
but wants to allow it later, they will have to do so via the system
settings.

Fixes: #78
Fixes: #80