### PR TITLE
Fix crash when receiving call from a private number

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -115,7 +115,7 @@ class RecorderThread(
                     }
                 }
 
-                if (details.handle.scheme == PhoneAccount.SCHEME_TEL) {
+                if (details.handle?.scheme == PhoneAccount.SCHEME_TEL) {
                     append('_')
                     append(details.handle.schemeSpecificPart)
 


### PR DESCRIPTION
When receiving a call from a private number, the `Call.Details` instance provided by Android has a null `Uri` for the handle. This isn't documented in the Android SDK.

This commit fixes the issue by adding a null check and also changes the error handling so that early failures (during creation of RecorderThread) will still result in an error notification being shown.

Fixes: #111