### PR TITLE
Add support for flashing via recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
     * **For devices rooted with Magisk**, simply flash the zip as a Magisk module from within the Magisk app.
         * **For OnePlus devices running the stock firmware (or custom firmware based on the stock firmware)**, also extract the `.apk` from the zip and install it manually before rebooting. This is necessary to work around a bug in the firmware where the app data directory does not get created, causing BCR to open up to a blank screen.
 
-    * **For unrooted custom firmware**, the files from the `system/` folder in the zip will need to be baked into the system image (or otherwise made available on the actual `/system` volume).
+    * **For unrooted custom firmware**, flash the zip while booted into recovery.
+        * Manually extracting the files from the `system/` folder in the zip will also work as long as the files have `644` permissions and the `u:object_r:system_file:s0` SELinux label.
 
 3. Reboot and open BCR.
 

--- a/app/magisk/update-binary
+++ b/app/magisk/update-binary
@@ -1,33 +1,40 @@
 #!/sbin/sh
 
-#################
-# Initialization
-#################
+OUTFD=${2}
+ZIPFILE=${3}
 
 umask 022
 
-# echo before loading util_functions
-ui_print() { echo "$1"; }
-
-require_new_magisk() {
-  ui_print "*******************************"
-  ui_print " Please install Magisk v20.4+! "
-  ui_print "*******************************"
-  exit 1
+ui_print() {
+    printf "ui_print %s\nui_print\n" "${*}" > /proc/self/fd/"${OUTFD}"
 }
 
-#########################
-# Load util_functions.sh
-#########################
+if [ -f /sbin/recovery ]; then
+    # Installing via recovery. Always do a direct install.
+    set -exu
 
-OUTFD=$2
-ZIPFILE=$3
+    ui_print 'Mounting system'
+    if mount /system_root; then
+        root_dir=/system_root
+    else
+        mount /system
+        root_dir=/
+    fi
 
-mount /data 2>/dev/null
+    ui_print 'Extracting files'
 
-[ -f /data/adb/magisk/util_functions.sh ] || require_new_magisk
-. /data/adb/magisk/util_functions.sh
-[ $MAGISK_VER_CODE -lt 20400 ] && require_new_magisk
+    # Just overwriting isn't sufficient because the apk filenames are different
+    # between debug and release builds
+    app_id=$(unzip -p "${ZIPFILE}" module.prop | grep '^id=' | cut -d= -f2)
+    rm -rf "${root_dir}/system/priv-app/${app_id}"
 
-install_module
-exit 0
+    unzip -o "${ZIPFILE}" 'system/*' -d "${root_dir}"
+
+    ui_print 'Done!'
+else
+    # Installing via Magisk Manager.
+
+    . /data/adb/magisk/util_functions.sh
+
+    install_module
+fi


### PR DESCRIPTION
This will install BCR directly into the system partition. With this installation method, Magisk is not involved at all.

Fixes: #128