### PR TITLE
update-binary: Explicitly remount as writable; Ignore cleanup failures due to ENOENT

### DIFF
--- a/app/magisk/update-binary
+++ b/app/magisk/update-binary
@@ -15,9 +15,11 @@ if [ -f /sbin/recovery ] || [ -f /system/bin/recovery ]; then
 
     ui_print 'Mounting system'
     if mount /system_root; then
+        mount -o remount,rw /system_root
         root_dir=/system_root
     else
         mount /system
+        mount -o remount,rw /system
         root_dir=/
     fi
 

--- a/app/magisk/update-binary
+++ b/app/magisk/update-binary
@@ -26,7 +26,9 @@ if [ -f /sbin/recovery ] || [ -f /system/bin/recovery ]; then
     # Just overwriting isn't sufficient because the apk filenames are different
     # between debug and release builds
     app_id=$(unzip -p "${ZIPFILE}" module.prop | grep '^id=' | cut -d= -f2)
-    rm -rf "${root_dir}/system/priv-app/${app_id}"
+
+    # rm on some custom recoveries doesn't exit with 0 on ENOENT, even with -f
+    rm -rf "${root_dir}/system/priv-app/${app_id}" || :
 
     unzip -o "${ZIPFILE}" 'system/*' -d "${root_dir}"
 


### PR DESCRIPTION
Fixes: #108
Fixes: #138