### PR TITLE
RecorderInCallService: Improve end-of-call detection

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -228,6 +228,7 @@ class RecorderThread(
      * [Uri].
      */
     fun cancel() {
+        Log.d(tag, "Requested cancellation")
         isCancelled = true
     }
 


### PR DESCRIPTION
On older Samsung firmware, the telephony framework fails to notify `InCallService` implementations about call disconnections. This doesn't just happen with BCR. It affects Samsung's own apps too, like Knox's `InCallServiceImpl`.

Due to this bug, none of the following callbacks are called when a call ends:

* `Call.Callback.onStateChanged` with `Call.STATE_DISCONNECTING` or `Call.STATE_DISCONNECTED`
* `Call.Callback.onCallDestroyed`
* `InCallService.onCallRemoved`

However, it does happen to call `Call.Callback.onDetailsChanged` when the call state transitions to `Call.STATE_DISCONNECTED` (which doesn't happen with AOSP).

This commit reworks `RecorderInCallService` to keep track of calls better in the face of these firmware bugs. A call's lifetime begins when `InCallService.onCallAdded` is called and ends when either `InCallService.onCallRemoved` is called or the state is `Call.STATE_DISCONNECTING` or `Call.STATE_DISCONNECTED` in any other callback.

This should work on both well-behaved firmware, like AOSP, and buggy firmware, like Samsung's OneUI.

Issue: #143