### PR TITLE
Send notification when a call recording completes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,10 @@ android {
 
         buildConfigField("String", "PROJECT_URL_AT_COMMIT",
             "\"${projectUrl}/tree/${gitVersionTriple.third.name}\"")
+
+        buildConfigField("String", "PROVIDER_AUTHORITY",
+            "APPLICATION_ID + \".provider\"")
+        resValue("string", "provider_authority", "$applicationId.provider")
     }
     sourceSets {
         getByName("main") {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,13 @@
             </intent-filter>
         </service>
 
+        <provider
+            android:authorities="@string/provider_authority"
+            android:name=".RecorderProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+        </provider>
+
         <activity
             android:name=".SettingsActivity"
             android:exported="true">

--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -1,0 +1,199 @@
+package com.chiller3.bcr
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+
+class Notifications(
+    private val context: Context,
+) {
+    companion object {
+        const val CHANNEL_ID_PERSISTENT = "persistent"
+        const val CHANNEL_ID_FAILURE = "failure"
+        const val CHANNEL_ID_SUCCESS = "success"
+
+        private val LEGACY_CHANNEL_IDS = arrayOf("alerts")
+
+        private var notificationId = 2
+    }
+
+    private val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+    /**
+     * Create a low priority notification channel for the persistent notification.
+     */
+    private fun createPersistentChannel() = NotificationChannel(
+        CHANNEL_ID_PERSISTENT,
+        context.getString(R.string.notification_channel_persistent_name),
+        NotificationManager.IMPORTANCE_LOW,
+    ).apply {
+        description = context.getString(R.string.notification_channel_persistent_desc)
+    }
+
+    /**
+     * Create a high priority notification channel for failure alerts.
+     */
+    private fun createFailureAlertsChannel() = NotificationChannel(
+        CHANNEL_ID_FAILURE,
+        context.getString(R.string.notification_channel_failure_name),
+        NotificationManager.IMPORTANCE_HIGH,
+    ).apply {
+        description = context.getString(R.string.notification_channel_failure_desc)
+    }
+
+    /**
+     * Create a high priority notification channel for success alerts.
+     */
+    private fun createSuccessAlertsChannel() = NotificationChannel(
+        CHANNEL_ID_SUCCESS,
+        context.getString(R.string.notification_channel_success_name),
+        NotificationManager.IMPORTANCE_HIGH,
+    ).apply {
+        description = context.getString(R.string.notification_channel_success_desc)
+    }
+
+    /**
+     * Ensure up-to-date notification channels exist, deleting legacy channels.
+     */
+    fun updateChannels() {
+        notificationManager.createNotificationChannels(listOf(
+            createPersistentChannel(),
+            createFailureAlertsChannel(),
+            createSuccessAlertsChannel(),
+        ))
+        LEGACY_CHANNEL_IDS.forEach { notificationManager.deleteNotificationChannel(it) }
+    }
+
+    /**
+     * Create a persistent notification for use during recording. The notification appearance is
+     * fully static and in progress recording is represented by the presence or absence of the
+     * notification.
+     */
+    fun createPersistentNotification(@StringRes title: Int, @DrawableRes icon: Int): Notification {
+        val notificationIntent = Intent(context, SettingsActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            context, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return Notification.Builder(context, CHANNEL_ID_PERSISTENT).run {
+            setContentTitle(context.getText(title))
+            setSmallIcon(icon)
+            setContentIntent(pendingIntent)
+            setOngoing(true)
+
+            // Inhibit 10-second delay when showing persistent notification
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+            }
+            build()
+        }
+    }
+
+    private fun createAlertNotification(
+        channel: String,
+        @StringRes title: Int,
+        @DrawableRes icon: Int,
+        errorMsg: String?,
+        file: OutputFile?,
+    ): Notification =
+        Notification.Builder(context, channel).run {
+            val text = buildString {
+                val errorMsgTrimmed = errorMsg?.trim()
+                if (!errorMsgTrimmed.isNullOrBlank()) {
+                    append(errorMsgTrimmed)
+                }
+                if (file != null) {
+                    if (!isEmpty()) {
+                        append("\n\n")
+                    }
+                    append(file.uri.formattedString)
+                }
+            }
+
+            setContentTitle(context.getString(title))
+            if (text.isNotBlank()) {
+                setContentText(text)
+                style = Notification.BigTextStyle()
+            }
+            setSmallIcon(icon)
+
+            if (file != null) {
+                // It is not possible to grant access to SAF URIs to other applications
+                val wrappedUri = RecorderProvider.fromOrigUri(file.uri)
+
+                val openIntent = PendingIntent.getActivity(
+                    context,
+                    0,
+                    Intent(Intent.ACTION_VIEW).apply {
+                        setDataAndType(wrappedUri, file.mimeType)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    },
+                    PendingIntent.FLAG_IMMUTABLE,
+                )
+                val shareIntent = PendingIntent.getActivity(
+                    context,
+                    0,
+                    Intent(Intent.ACTION_SEND).apply {
+                        type = file.mimeType
+                        putExtra(Intent.EXTRA_STREAM, wrappedUri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    },
+                    PendingIntent.FLAG_IMMUTABLE,
+                )
+
+                addAction(Notification.Action.Builder(
+                    null,
+                    context.getString(R.string.notification_action_open),
+                    openIntent,
+                ).build())
+
+                addAction(Notification.Action.Builder(
+                    null,
+                    context.getString(R.string.notification_action_share),
+                    shareIntent,
+                ).build())
+
+                // Clicking on the notification behaves like the open action, except the
+                // notification gets dismissed. The open and share actions do not dismiss the
+                // notification.
+                setContentIntent(openIntent)
+                setAutoCancel(true)
+            }
+
+            build()
+        }
+
+    private fun notify(notification: Notification) {
+        notificationManager.notify(notificationId, notification)
+        ++notificationId
+    }
+
+    fun notifySuccess(
+        @StringRes title: Int,
+        @DrawableRes icon: Int,
+        file: OutputFile,
+    ) {
+        notify(createAlertNotification(CHANNEL_ID_SUCCESS, title, icon, null, file))
+    }
+
+    fun notifyFailure(
+        @StringRes title: Int,
+        @DrawableRes icon: Int,
+        errorMsg: String?,
+        file: OutputFile?,
+    ) {
+        notify(createAlertNotification(CHANNEL_ID_FAILURE, title, icon, errorMsg, file))
+    }
+
+    fun dismissAll() {
+        // This is safe to run at any time because it doesn't dismiss notifications belonging to
+        // foreground services.
+        notificationManager.cancelAll()
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/OutputFile.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputFile.kt
@@ -1,0 +1,8 @@
+package com.chiller3.bcr
+
+import android.net.Uri
+
+data class OutputFile(
+    val uri: Uri,
+    val mimeType: String,
+)

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -100,7 +100,8 @@ class Preferences(private val context: Context) {
                     // Persist permissions for the new URI first
                     context.contentResolver.takePersistableUriPermission(
                         uri,
-                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                     )
                     putString(PREF_OUTPUT_DIR, uri.toString())
                 } else {
@@ -113,9 +114,14 @@ class Preferences(private val context: Context) {
             if (oldUri != null) {
                 context.contentResolver.releasePersistableUriPermission(
                     oldUri,
-                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                 )
             }
+
+            // Clear all alert notifications. Having them disappear is a better user experience than
+            // having the open/share actions use a no-longer-valid URI.
+            Notifications(context).dismissAll()
         }
 
     /**

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -1,51 +1,15 @@
 package com.chiller3.bcr
 
 import android.app.Application
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import com.google.android.material.color.DynamicColors
 
 class RecorderApplication : Application() {
-    companion object {
-        const val CHANNEL_ID_PERSISTENT = "persistent"
-        const val CHANNEL_ID_ALERTS = "alerts"
-    }
-
     override fun onCreate() {
         super.onCreate()
 
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)
 
-        createPersistentChannel()
-        createAlertsChannel()
-    }
-
-    /**
-     * Create a low priority notification channel for the persistent notification.
-     */
-    private fun createPersistentChannel() {
-        val name = getString(R.string.notification_channel_persistent_name)
-        val description = getString(R.string.notification_channel_persistent_desc)
-        val channel = NotificationChannel(
-            CHANNEL_ID_PERSISTENT, name, NotificationManager.IMPORTANCE_LOW)
-        channel.description = description
-
-        val notificationManager = getSystemService(NotificationManager::class.java)
-        notificationManager.createNotificationChannel(channel)
-    }
-
-    /**
-     * Create a high priority notification channel for alerts.
-     */
-    private fun createAlertsChannel() {
-        val name = getString(R.string.notification_channel_alerts_name)
-        val description = getString(R.string.notification_channel_alerts_desc)
-        val channel = NotificationChannel(
-            CHANNEL_ID_ALERTS, name, NotificationManager.IMPORTANCE_HIGH)
-        channel.description = description
-
-        val notificationManager = getSystemService(NotificationManager::class.java)
-        notificationManager.createNotificationChannel(channel)
+        Notifications(this).updateChannels()
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/RecorderProvider.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderProvider.kt
@@ -1,0 +1,80 @@
+package com.chiller3.bcr
+
+import android.content.ContentProvider
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Intent
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+
+/**
+ * This is an extremely minimal content provider so that BCR can provide an openable/shareable URI
+ * to other applications. SAF URIs cannot be shared directly because permission grants cannot be
+ * propagated to the target app.
+ *
+ * This content provider is not exported and access is only granted to specific URIs via
+ * [Intent.FLAG_GRANT_READ_URI_PERMISSION].
+ */
+class RecorderProvider : ContentProvider() {
+    companion object {
+        private const val QUERY_ORIG = "orig"
+
+        fun fromOrigUri(origUri: Uri): Uri =
+            Uri.Builder().run {
+                scheme(ContentResolver.SCHEME_CONTENT)
+                authority(BuildConfig.PROVIDER_AUTHORITY)
+                appendQueryParameter(QUERY_ORIG, origUri.toString())
+
+                build()
+            }
+
+        private fun extractOrigUri(uri: Uri): Uri? {
+            val param = uri.getQueryParameter(QUERY_ORIG)
+            if (param.isNullOrBlank()) {
+                return null
+            }
+
+            return try {
+                Uri.parse(param)
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+
+    override fun onCreate(): Boolean = true
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? =
+        extractOrigUri(uri)?.let {
+            context?.contentResolver?.openFileDescriptor(it, mode)
+        }
+
+    override fun getType(uri: Uri): String? =
+        extractOrigUri(uri)?.let {
+            context?.contentResolver?.getType(it)
+        }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? =
+        extractOrigUri(uri)?.let {
+            context?.contentResolver?.query(
+                it, projection, selection, selectionArgs, sortOrder)
+        }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+    ): Int = 0
+}

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -210,10 +210,12 @@ class RecorderThread(
                 Log.w(tag, "Failed to dump logcat", e)
             }
 
+            val outputFile = resultUri?.let { OutputFile(it, format.mimeTypeContainer) }
+
             if (success) {
-                listener.onRecordingCompleted(this, resultUri!!)
+                listener.onRecordingCompleted(this, outputFile!!)
             } else {
-                listener.onRecordingFailed(this, errorMsg, resultUri)
+                listener.onRecordingFailed(this, errorMsg, outputFile)
             }
         }
     }
@@ -613,15 +615,15 @@ class RecorderThread(
 
     interface OnRecordingCompletedListener {
         /**
-         * Called when the recording completes successfully. [uri] is the output file.
+         * Called when the recording completes successfully. [file] is the output file.
          */
-        fun onRecordingCompleted(thread: RecorderThread, uri: Uri)
+        fun onRecordingCompleted(thread: RecorderThread, file: OutputFile)
 
         /**
-         * Called when an error occurs during recording. If [uri] is not null, it points to the
-         * output file containing partially recorded audio. If [uri] is null, then either the output
-         * file could not be created or the thread was cancelled before it was started.
+         * Called when an error occurs during recording. If [file] is not null, it points to the
+         * output file containing partially recorded audio. If [file] is null, then either the
+         * output file could not be created or the thread was cancelled before it was started.
          */
-        fun onRecordingFailed(thread: RecorderThread, errorMsg: String?, uri: Uri?)
+        fun onRecordingFailed(thread: RecorderThread, errorMsg: String?, file: OutputFile?)
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/UriExtensions.kt
@@ -16,7 +16,15 @@ val Uri.formattedString: String
             val treeIndex = segments.indexOf("tree")
 
             if (treeIndex >= 0 && treeIndex < segments.size - 1) {
-                segments[treeIndex + 1]
+                // The URI might have /document/<path> appended if it refers to a document instead
+                // of a tree
+                val docIndex = treeIndex + 2
+
+                if (docIndex < segments.size - 1 && segments[docIndex] == "document") {
+                    segments[docIndex + 1]
+                } else {
+                    segments[treeIndex + 1]
+                }
             } else {
                 toString()
             }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -42,8 +42,7 @@
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Servicios en segundo plano</string>
     <string name="notification_channel_persistent_desc">Notificación persistente para grabación de llamadas en segundo plano</string>
-    <string name="notification_channel_alerts_name">Alertas</string>
-    <string name="notification_channel_alerts_desc">Alertas de errores durante la grabación de llamadas</string>
+    <string name="notification_channel_failure_desc">Alertas de errores durante la grabación de llamadas</string>
     <string name="notification_recording_in_progress">Grabación de llamadas en curso</string>
     <string name="notification_recording_failed">No se pudo grabar la llamada</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,8 +42,7 @@
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Service d\'arrière-plan</string>
     <string name="notification_channel_persistent_desc">Notification persistante pour l\'enregistrement en arrière-plan</string>
-    <string name="notification_channel_alerts_name">Alertes</string>
-    <string name="notification_channel_alerts_desc">Alertes d\'erreurs pendant l\'enregistrement</string>
+    <string name="notification_channel_failure_desc">Alertes d\'erreurs pendant l\'enregistrement</string>
     <string name="notification_recording_in_progress">Enregistrement d\'appel en cours</string>
     <string name="notification_recording_failed">Enregistrement d\'appel échoué</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -43,8 +43,7 @@
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Usługi w tle</string>
     <string name="notification_channel_persistent_desc">Stałe powiadomienie o nagrywaniu rozmów w tle</string>
-    <string name="notification_channel_alerts_name">Alerty</string>
-    <string name="notification_channel_alerts_desc">Alerty o błędach podczas nagrywania rozmów</string>
+    <string name="notification_channel_failure_desc">Alerty o błędach podczas nagrywania rozmów</string>
     <string name="notification_recording_in_progress">Trwa nagrywanie rozmowy</string>
     <string name="notification_recording_failed">Nie udało się nagrać rozmowy</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -43,8 +43,7 @@
     <string name="notification_channel_persistent_name">Фоновые сервисы</string>
     <string name="notification_channel_persistent_desc">Постоянное уведомление для записи вызовов в фоновом режиме</string>
     <string name="notification_recording_in_progress">Происходит запись вызова</string>
-    <string name="notification_channel_alerts_desc">Оповещение об ошибках во время записи разговора</string>
-    <string name="notification_channel_alerts_name">Оповещения</string>
+    <string name="notification_channel_failure_desc">Оповещение об ошибках во время записи разговора</string>
     <string name="notification_recording_failed">Не удалось записать звонок</string>
 
     <!-- Quick settings tile -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -43,8 +43,7 @@
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Služby na pozadí</string>
     <string name="notification_channel_persistent_desc">Trvalé upozornenie na nahrávanie hovorov</string>
-    <string name="notification_channel_alerts_name">Upozornenia</string>
-    <string name="notification_channel_alerts_desc">Upozornenia na chyby počas nahrávania</string>
+    <string name="notification_channel_failure_desc">Upozornenia na chyby počas nahrávania</string>
     <string name="notification_recording_in_progress">Nahrávanie telefonického hovoru</string>
     <string name="notification_recording_failed">Nahrávanie hovoru zlyhalo</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -41,8 +41,7 @@
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Arka plan servisleri</string>
     <string name="notification_channel_persistent_desc">Arka plan çağrı kaydı için kalıcı bildirim</string>
-    <string name="notification_channel_alerts_name">Uyarılar</string>
-    <string name="notification_channel_alerts_desc">Kayıt esnasındaki hatalar için uyarılar</string>
+    <string name="notification_channel_failure_desc">Kayıt esnasındaki hatalar için uyarılar</string>
     <string name="notification_recording_in_progress">Çağrı kaydediliyor</string>
     <string name="notification_recording_failed">Çağrı kaydı başarısız</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,10 +42,15 @@
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Background services</string>
     <string name="notification_channel_persistent_desc">Persistent notification for background call recording</string>
-    <string name="notification_channel_alerts_name">Alerts</string>
-    <string name="notification_channel_alerts_desc">Alerts for errors during call recording</string>
+    <string name="notification_channel_failure_name">Failure alerts</string>
+    <string name="notification_channel_failure_desc">Alerts for errors during call recording</string>
+    <string name="notification_channel_success_name">Success alerts</string>
+    <string name="notification_channel_success_desc">Alerts for successful call recordings</string>
     <string name="notification_recording_in_progress">Call recording in progress</string>
     <string name="notification_recording_failed">Failed to record call</string>
+    <string name="notification_recording_succeeded">Successfully recorded call</string>
+    <string name="notification_action_open">Open</string>
+    <string name="notification_action_share">Share</string>
 
     <!-- Quick settings tile -->
     <string name="quick_settings_label">Call recording</string>


### PR DESCRIPTION
This commit adds a new notification that fires when a call recording completes successfully. It's associated with a new notification channel so it can be disabled without affecting other notifications.

The notification has two action buttons: open and share. Both of these do as their name implies and do not dismiss the notification. Clicking on the notification text behaves like open, except the notification is dismissed.

The open and share options require a custom ContentProvider because it's not possible to grant the target app permissions to a SAF URI. BCR's RecorderProvider is very minimal and just wraps SAF's provider for the openFile, getType, and query operations.

Also, manual action from the user is required for the new open and share options to work. Previously, BCR only requested persistent write permissions to the output directory. This makes it impossible for RecorderProvider to access the recording that was just created. This commit updates the output directory permission logic to also request persistent read permissions, but the user will have to reset the output directory to the default and then select the desired directory again.