### PR TITLE
README.md: Add note about erofs volumes being read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
         * **For OnePlus and Realme devices running the stock firmware (or custom firmware based on the stock firmware)**, also extract the `.apk` from the zip and install it manually before rebooting. This is necessary to work around a bug in the firmware where the app data directory does not get created, causing BCR to open up to a blank screen.
 
     * **For unrooted custom firmware**, flash the zip while booted into recovery.
+        * **NOTE**: If the custom firmware's `system` partition is formatted with `erofs`, then the filesystem is read-only and it is not possible to use this method.
         * Manually extracting the files from the `system/` folder in the zip will also work as long as the files have `644` permissions and the `u:object_r:system_file:s0` SELinux label.
 
 3. Reboot and open BCR.


### PR DESCRIPTION
There's unfortunately nothing BCR can do for read-only filesystems. For those setups, Magisk is the best option.

Closes: #163