### PR TITLE
Explicitly vibrate when vibration is enabled for a notification channel

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:name=".RecorderApplication"

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -201,6 +201,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
                 R.string.notification_recording_in_progress,
                 R.drawable.ic_launcher_quick_settings,
             ))
+            notifications.vibrateIfEnabled(Notifications.CHANNEL_ID_PERSISTENT)
         }
     }
 


### PR DESCRIPTION
Android's vibration setting seemingly has no effect when the user is in a phone call, which is always the case when a BCR notification is shown. With this commit, BCR will explicitly vibrate the device using a pattern that mimics what Android does by default for notifications.

This commit is inspired by @quyenvsp's PR #167, except it relies on Android notification channels' builtin vibration setting instead of adding a new setting to BCR.

Related PR: #167