### PR TITLE
Add SIM slot ID to the filename if there are multiple active SIMs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -20,7 +20,10 @@ object Permissions {
         }
 
     val REQUIRED: Array<String> = arrayOf(Manifest.permission.RECORD_AUDIO) + NOTIFICATION
-    val OPTIONAL: Array<String> = arrayOf(Manifest.permission.READ_CONTACTS)
+    val OPTIONAL: Array<String> = arrayOf(
+        Manifest.permission.READ_CONTACTS,
+        Manifest.permission.READ_PHONE_STATE,
+    )
 
     private fun isGranted(context: Context, permission: String) =
         ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED


### PR DESCRIPTION
This only works if all of these conditions are true:
* Android version is >= 11
* The user granted the `READ_PHONE_STATE` permission
* The device supports `FEATURE_TELEPHONY_SUBSCRIPTION`
* The device supports multiple SIMs
* There are currently multiple active SIMs

Fixes: #177