### PR TITLE
Fix broken share action due to PendingIntent reuse

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -199,7 +199,10 @@ class Notifications(
                     context,
                     0,
                     Intent(Intent.ACTION_SEND).apply {
-                        type = file.mimeType
+                        // The data is not used for ACTION_SEND, but it makes Intent.filterEquals()
+                        // return false and prevents the same PendingIntent being used when multiple
+                        // notifications are shown.
+                        setDataAndType(wrappedUri, file.mimeType)
                         putExtra(Intent.EXTRA_STREAM, wrappedUri)
                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     },


### PR DESCRIPTION
The intent for the "share" action is not distinguishable across notifications when compared with Intent.filterEquals() because they differ only in intent extras. This would cause the same PendingIntent to be reused for every share action, which would reference an old URI.

This commit fixes the issue by setting the ACTION_SEND data to the same value as the EXTRA_STREAM. The intent data is not used for this action, but makes the intent sufficiently unique that a PendingIntent won't be reused.