### PR TITLE
Add a new notification action for deleting the recording

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,10 @@
         android:theme="@style/Theme.BCR">
 
         <service
+            android:name=".NotificationActionService"
+            android:exported="false" />
+
+        <service
             android:name=".RecorderInCallService"
             android:enabled="true"
             android:exported="true"

--- a/app/src/main/java/com/chiller3/bcr/NotificationActionService.kt
+++ b/app/src/main/java/com/chiller3/bcr/NotificationActionService.kt
@@ -1,0 +1,92 @@
+package com.chiller3.bcr
+
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+
+class NotificationActionService : Service() {
+    companion object {
+        private val TAG = NotificationActionService::class.java.simpleName
+
+        private val ACTION_DELETE_URI = "${NotificationActionService::class.java.canonicalName}.delete_uri"
+        private const val EXTRA_REDACTED = "redacted"
+        private const val EXTRA_NOTIFICATION_ID = "notification_id"
+
+        private fun intentFromFile(context: Context, file: OutputFile): Intent =
+            Intent(context, NotificationActionService::class.java).apply {
+                setDataAndType(file.uri, file.mimeType)
+                putExtra(EXTRA_REDACTED, file.redacted)
+            }
+
+        fun createDeleteUriIntent(context: Context, file: OutputFile, notificationId: Int): Intent =
+            intentFromFile(context, file).apply {
+                action = ACTION_DELETE_URI
+                putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+            }
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    private fun parseFileFromIntent(intent: Intent): OutputFile =
+        OutputFile(
+            intent.data!!,
+            intent.getStringExtra(EXTRA_REDACTED)!!,
+            intent.type!!,
+        )
+
+    private fun parseDeleteUriIntent(intent: Intent): Pair<OutputFile, Int> {
+        val file = parseFileFromIntent(intent)
+
+        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        if (notificationId < 0) {
+            throw IllegalArgumentException("Invalid notification ID: $notificationId")
+        }
+
+        return Pair(file, notificationId)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
+        try {
+            when (intent?.action) {
+                ACTION_DELETE_URI -> {
+                    val (file, notificationId) = parseDeleteUriIntent(intent)
+                    val documentFile = file.toDocumentFile(this)
+                    val notificationManager = getSystemService(NotificationManager::class.java)
+
+                    Thread {
+                        Log.d(TAG, "Deleting: ${file.redacted}")
+                        try {
+                            documentFile.delete()
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to delete ${file.redacted}", e)
+                        }
+
+                        handler.post {
+                            notificationManager.cancel(notificationId)
+                            stopSelf(startId)
+                        }
+                    }.start()
+                }
+                else -> throw IllegalArgumentException("Invalid action: ${intent.action}")
+            }
+
+            START_REDELIVER_INTENT
+        } catch (e: Exception) {
+            val redactedIntent = intent?.let { Intent(it) }?.apply {
+                setDataAndType(Uri.fromParts("redacted", "", ""), type)
+            }
+
+            Log.w(TAG, "Failed to handle intent: $redactedIntent", e)
+            stopSelf(startId)
+
+            START_NOT_STICKY
+        }
+}

--- a/app/src/main/java/com/chiller3/bcr/OutputFile.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputFile.kt
@@ -1,8 +1,29 @@
 package com.chiller3.bcr
 
+import android.content.ContentResolver
+import android.content.Context
 import android.net.Uri
+import androidx.core.net.toFile
+import androidx.documentfile.provider.DocumentFile
 
 data class OutputFile(
+    /**
+     * URI to a single file, which may have a [ContentResolver.SCHEME_FILE] or
+     * [ContentResolver.SCHEME_CONTENT] scheme.
+     */
     val uri: Uri,
+
+    /** String representation of [uri] with private information redacted. */
+    val redacted: String,
+
+    /** MIME type of [uri]'s contents. */
     val mimeType: String,
-)
+) {
+    fun toDocumentFile(context: Context): DocumentFile =
+        when (uri.scheme) {
+            ContentResolver.SCHEME_FILE -> DocumentFile.fromFile(uri.toFile())
+            // Only returns null on API <19
+            ContentResolver.SCHEME_CONTENT -> DocumentFile.fromSingleUri(context, uri)!!
+            else -> throw IllegalArgumentException("Invalid URI scheme: $redacted")
+        }
+}

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -228,7 +228,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     }
 
     override fun onRecordingCompleted(thread: RecorderThread, file: OutputFile) {
-        Log.i(TAG, "Recording completed: ${thread.id}: ${thread.redact(file.uri)}")
+        Log.i(TAG, "Recording completed: ${thread.id}: ${file.redacted}")
         handler.post {
             onThreadExited()
 
@@ -237,7 +237,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     }
 
     override fun onRecordingFailed(thread: RecorderThread, errorMsg: String?, file: OutputFile?) {
-        Log.w(TAG, "Recording failed: ${thread.id}: ${file?.uri?.let { thread.redact(it) }}")
+        Log.w(TAG, "Recording failed: ${thread.id}: ${file?.redacted}")
         handler.post {
             onThreadExited()
 

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -101,7 +101,7 @@ class RecorderThread(
         }
     }
 
-    fun redact(uri: Uri): String = redact(Uri.decode(uri.toString()))
+    private fun redact(uri: Uri): String = redact(Uri.decode(uri.toString()))
 
     /**
      * Update [filename] with information from [details].
@@ -232,7 +232,7 @@ class RecorderThread(
                 Log.w(tag, "Failed to dump logcat", e)
             }
 
-            val outputFile = resultUri?.let { OutputFile(it, format.mimeTypeContainer) }
+            val outputFile = resultUri?.let { OutputFile(it, redact(it), format.mimeTypeContainer) }
 
             if (success) {
                 listener.onRecordingCompleted(this, outputFile!!)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="notification_recording_succeeded">Successfully recorded call</string>
     <string name="notification_action_open">Open</string>
     <string name="notification_action_share">Share</string>
+    <string name="notification_action_delete">Delete</string>
 
     <!-- Quick settings tile -->
     <string name="quick_settings_label">Call recording</string>


### PR DESCRIPTION
The new Delete action will show up alongside the current Open and Share actions, but unlike those other two actions, Delete will also dismiss the notification.

Fixes: #179