### PR TITLE
Allow changing output settings while call recording is disabled

### DIFF
--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -10,7 +10,6 @@
             app:iconSpaceReserved="false" />
 
         <Preference
-            app:dependency="call_recording"
             app:key="output_dir"
             app:persistent="false"
             app:title="@string/pref_output_dir_name"
@@ -18,7 +17,6 @@
             app:iconSpaceReserved="false" />
 
         <Preference
-            app:dependency="call_recording"
             app:key="output_format"
             app:persistent="false"
             app:title="@string/pref_output_format_name"


### PR DESCRIPTION
There's no technical reason to disable these settings until call recording is enabled. It's even safe to change the settings while a recording is in progress.