### PR TITLE
Update Polish translations

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -49,12 +49,16 @@
     <string name="notification_channel_success_name">Zakończone nagrywanie</string>
     <string name="notification_channel_success_desc">Informacje o pomyślnym nagraniu rozmowy</string>
     <string name="notification_recording_in_progress">Trwa nagrywanie rozmowy</string>
+    <string name="notification_recording_mic_in_progress">Trwa nagrywanie dźwięku</string>
     <string name="notification_recording_failed">Nie udało się nagrać rozmowy</string>
+    <string name="notification_recording_mic_failed">Nie udało się nagrać dźwięku</string>
     <string name="notification_recording_succeeded">Pomyślnie nagrano rozmowę</string>
+    <string name="notification_recording_mic_succeeded">Pomyślnie nagrano dźwięk</string>
     <string name="notification_action_open">Otwórz</string>
     <string name="notification_action_share">Udostępnij</string>
     <string name="notification_action_delete">Usuń</string>
 
     <!-- Quick settings tile -->
     <string name="quick_settings_label">Nagrywanie rozmów</string>
+    <string name="quick_settings_mic_label">Nagrywanie dźwięku</string>
 </resources>


### PR DESCRIPTION
#193 in separate PR to keep the history clean.

> Note: "mic recording" became "sound recording" here in Polish version. Translating it literally (and more correctly) would require something like "recording with microphone" ("nagrywanie mikrofonem"), which is a bit unwieldy. There is some unfortunate semantic overlap between call and sound, but I hope it will be clear enough.