### PR TITLE
Add support for custom timestamp patterns in the output filename

### DIFF
--- a/app/src/main/res/raw/filename_template.properties
+++ b/app/src/main/res/raw/filename_template.properties
@@ -29,7 +29,18 @@
 #   log file in the output directory. Search for `FilenameTemplate` in the log
 #   file.
 
-# Time of call. Must always be the first component.
+# Timestamp of call. Must always be the first component. The default date/time
+# format includes the date, time (up to milliseconds), and timezone to ensure
+# that the timestamp is never ambiguous. For example, 20230101_010203.456+0000.
+#
+# To use a custom date/time format, add a colon followed by the format string.
+# See the bottom of this file for an example. The complete list of valid format
+# characters can be found at:
+# https://developer.android.com/reference/java/time/format/DateTimeFormatterBuilder#appendPattern(java.lang.String)
+#
+# NOTE: If you use the file retention feature and you change this option,
+# remember to manually rename the existing files. That feature requires the
+# timestamps in the filenames to have the expected pattern.
 filename.0.text = ${date}
 
 # Call direction, which is either `in` or `out`. Only defined on Android 10+.
@@ -55,6 +66,10 @@ filename.5.text = ${contact_name}
 filename.5.prefix = _
 
 ################################################################################
+
+# Example: Use a shorter timestamp that only includes the date and time (up to
+# seconds). This will result in a timestamp like 20230101_010203.
+#filename.0.text = ${date:yyyyMMdd_HHmmss}
 
 # Example: Add the call direction to the filename with a leading underscore. If
 # the call direction can't be determined, then add "unknown" instead.


### PR DESCRIPTION
This commit adds support for specifying the timestamp pattern via the `${date:...}` syntax. For example, `${date:yyyyMMdd_HHmmss}`. Old files are not renamed; the user is responsible for doing so manually. If the user doesn't do so, the old files will likely be ignored by the file rentention cleanup process.

Implements: #204