### PR TITLE
Add friendlier message when recording fails due to AudioRecord

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -262,7 +262,17 @@ class RecorderThread(
             }
         } catch (e: Exception) {
             Log.e(tag, "Error during recording", e)
-            errorMsg = e.localizedMessage
+
+            errorMsg = buildString {
+                val elem = e.stackTrace.find { it.className.startsWith("android.media.") }
+                if (elem != null) {
+                    append(context.getString(R.string.notification_internal_android_error,
+                        "${elem.className}.${elem.methodName}"))
+                    append("\n\n")
+                }
+
+                append(e.localizedMessage)
+            }
         } finally {
             Log.i(tag, "Recording thread completed")
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="notification_recording_in_progress">Call recording in progress</string>
     <string name="notification_recording_failed">Failed to record call</string>
     <string name="notification_recording_succeeded">Successfully recorded call</string>
+    <string name="notification_internal_android_error">The recording failed in an internal Android component (%s). This device or firmware might not support call recording.</string>
     <string name="notification_action_open">Open</string>
     <string name="notification_action_share">Share</string>
     <string name="notification_action_delete">Delete</string>


### PR DESCRIPTION
There's nothing BCR can do if the device does not support call recording, so let's add a message about that when the exception stack trace involves `android.media.*` classes.