### PR TITLE
FilenameTemplate: Fix potential crash when a variable's value contains `\` or `$`

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/FilenameTemplate.kt
+++ b/app/src/main/java/com/chiller3/bcr/FilenameTemplate.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import java.util.*
+import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 class FilenameTemplate private constructor(props: Properties) {
@@ -77,7 +78,7 @@ class FilenameTemplate private constructor(props: Properties) {
                     val name = m.group(1)!!
                     val replacement = getVar(index, name)
 
-                    m.appendReplacement(this, replacement ?: "")
+                    m.appendReplacement(this, Matcher.quoteReplacement(replacement ?: ""))
 
                     ++index
                 }


### PR DESCRIPTION
Matcher.appendReplacement() treats `\` and `$` specially, so we need to use Matcher.quoteReplacement() when passing in arbitrary strings.

Fixes: #207