### PR TITLE
Add support for pausing/resuming the recording

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -124,7 +124,12 @@ class Notifications(
      * fully static and in progress recording is represented by the presence or absence of the
      * notification.
      */
-    fun createPersistentNotification(@StringRes title: Int, @DrawableRes icon: Int): Notification {
+    fun createPersistentNotification(
+        @StringRes title: Int,
+        @DrawableRes icon: Int,
+        @StringRes actionText: Int,
+        actionIntent: Intent,
+    ): Notification {
         val notificationIntent = Intent(context, SettingsActivity::class.java)
         val pendingIntent = PendingIntent.getActivity(
             context, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE
@@ -135,6 +140,19 @@ class Notifications(
             setSmallIcon(icon)
             setContentIntent(pendingIntent)
             setOngoing(true)
+
+            val actionPendingIntent = PendingIntent.getService(
+                context,
+                0,
+                actionIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+            addAction(Notification.Action.Builder(
+                null,
+                context.getString(actionText),
+                actionPendingIntent,
+            ).build())
 
             // Inhibit 10-second delay when showing persistent notification
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,12 +47,15 @@
     <string name="notification_channel_success_name">Success alerts</string>
     <string name="notification_channel_success_desc">Alerts for successful call recordings</string>
     <string name="notification_recording_in_progress">Call recording in progress</string>
+    <string name="notification_recording_paused">Call recording paused</string>
     <string name="notification_recording_failed">Failed to record call</string>
     <string name="notification_recording_succeeded">Successfully recorded call</string>
     <string name="notification_internal_android_error">The recording failed in an internal Android component (%s). This device or firmware might not support call recording.</string>
     <string name="notification_action_open">Open</string>
     <string name="notification_action_share">Share</string>
     <string name="notification_action_delete">Delete</string>
+    <string name="notification_action_pause">Pause</string>
+    <string name="notification_action_resume">Resume</string>
 
     <!-- Quick settings tile -->
     <string name="quick_settings_label">Call recording</string>


### PR DESCRIPTION
This commit implements basic pause/resume functionality via a notification action in BCR's persistent notification. Pausing is implemented by keeping the AudioRecord active, but discarding the data instead of passing it to the encoder. Pausing/resuming does not happen immediately, but after the processing of one buffer (which should be under 50ms on most devices). It's fast enough to be imperceptible.

Issue: #198