### PR TITLE
Add new option for starting the recording in the paused state

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -12,6 +12,7 @@ import java.io.File
 class Preferences(private val context: Context) {
     companion object {
         const val PREF_CALL_RECORDING = "call_recording"
+        const val PREF_INITIALLY_PAUSED = "initially_paused"
         const val PREF_OUTPUT_DIR = "output_dir"
         const val PREF_OUTPUT_FORMAT = "output_format"
         const val PREF_INHIBIT_BATT_OPT = "inhibit_batt_opt"
@@ -146,6 +147,13 @@ class Preferences(private val context: Context) {
     var isCallRecordingEnabled: Boolean
         get() = prefs.getBoolean(PREF_CALL_RECORDING, false)
         set(enabled) = prefs.edit { putBoolean(PREF_CALL_RECORDING, enabled) }
+
+    /**
+     * Whether the recording should initially start in the paused state.
+     */
+    var initiallyPaused: Boolean
+        get() = prefs.getBoolean(PREF_INITIALLY_PAUSED, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_INITIALLY_PAUSED, enabled) }
 
     /**
      * The saved output format.

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -295,12 +295,16 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         updateForegroundState()
     }
 
-    override fun onRecordingCompleted(thread: RecorderThread, file: OutputFile) {
-        Log.i(TAG, "Recording completed: ${thread.id}: ${file.redacted}")
+    override fun onRecordingCompleted(thread: RecorderThread, file: OutputFile?) {
+        Log.i(TAG, "Recording completed: ${thread.id}: ${file?.redacted}")
         handler.post {
             onThreadExited()
 
-            notifySuccess(file)
+            // If the recording was initially paused and the user never resumed it, there's no
+            // output file, so nothing needs to be shown.
+            if (file != null) {
+                notifySuccess(file)
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,10 @@
     <string name="pref_call_recording_name">Call recording</string>
     <string name="pref_call_recording_desc">Record incoming and outgoing phone calls. Microphone and notification permissions are required for recording in the background.</string>
 
+    <string name="pref_initially_paused_name">Initially paused</string>
+    <string name="pref_initially_paused_desc_on">Start recording in the paused state. If the recording is never resumed, then the empty output file won\'t be saved.</string>
+    <string name="pref_initially_paused_desc_off">Start recording immediately when a call connects. To pause or resume, tap on the button in the notification during a call.</string>
+
     <string name="pref_output_dir_name">Output directory</string>
     <string name="pref_output_dir_desc">Pick a directory to store recordings.</string>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -9,6 +9,13 @@
             app:summary="@string/pref_call_recording_desc"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            app:key="initially_paused"
+            app:title="@string/pref_initially_paused_name"
+            app:summaryOff="@string/pref_initially_paused_desc_off"
+            app:summaryOn="@string/pref_initially_paused_desc_on"
+            app:iconSpaceReserved="false" />
+
         <Preference
             app:key="output_dir"
             app:persistent="false"


### PR DESCRIPTION
This commit adds a new "initially paused" option to BCR's UI. If it's disabled, then BCR works as it always has: calls are recorded as soon as they enter the connected state. If the option is enabled, then the recording starts in the paused state. The user can choose to resume via BCR's persistent notification. If the recording is never resumed, then the empty output file is deleted and no success notification will be shown.

This new option is disabled by default.

Issue: #198