### PR TITLE
Change "initially paused" preference description

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
 
     <string name="pref_initially_paused_name">Initially paused</string>
     <string name="pref_initially_paused_desc_on">Recording will be paused after starting. If you don't resume it using the button in the notification, the empty output file won\'t be saved.</string>
-    <string name="pref_initially_paused_desc_off">Call will be recorded immediately after connecting. To pause or resume, tap on the button in the notification displayed during a call.</string>
+    <string name="pref_initially_paused_desc_off">Call will be recorded immediately after connecting. To pause and resume, tap on the button in the notification displayed during a call.</string>
 
     <string name="pref_output_dir_name">Output directory</string>
     <string name="pref_output_dir_desc">Pick a directory to store recordings.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="pref_call_recording_desc">Record incoming and outgoing phone calls. Microphone and notification permissions are required for recording in the background.</string>
 
     <string name="pref_initially_paused_name">Initially paused</string>
-    <string name="pref_initially_paused_desc_on">Recording will be paused after starting. If you don't resume it using the button in the notification, the empty output file won\'t be saved.</string>
+    <string name="pref_initially_paused_desc_on">Recording will be paused after starting. If you don\'t resume it using the button in the notification, the empty output file won\'t be saved.</string>
     <string name="pref_initially_paused_desc_off">Call will be recorded immediately after connecting. To pause and resume, tap on the button in the notification displayed during a call.</string>
 
     <string name="pref_output_dir_name">Output directory</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,8 @@
     <string name="pref_call_recording_desc">Record incoming and outgoing phone calls. Microphone and notification permissions are required for recording in the background.</string>
 
     <string name="pref_initially_paused_name">Initially paused</string>
-    <string name="pref_initially_paused_desc_on">Start recording in the paused state. If the recording is never resumed, then the empty output file won\'t be saved.</string>
-    <string name="pref_initially_paused_desc_off">Start recording immediately when a call connects. To pause or resume, tap on the button in the notification during a call.</string>
+    <string name="pref_initially_paused_desc_on">Recording will be paused after starting. If you don't resume it using the button in the notification, the empty output file won\'t be saved.</string>
+    <string name="pref_initially_paused_desc_off">Call will be recorded immediately after connecting. To pause or resume, tap on the button in the notification displayed during a call.</string>
 
     <string name="pref_output_dir_name">Output directory</string>
     <string name="pref_output_dir_desc">Pick a directory to store recordings.</string>


### PR DESCRIPTION
Since we have separate strings for on/off states, I think it's best to tell user what _will_ happen in the current state, not what they can _tell_ us to do (subtle difference between imperative "start in the paused state" and "will be paused after starting").

#219 has the same wording now, and I thought the English version might use some changes as well.

The "on" description could also have the "displayed during a call" part, but this would get too long, wouldn't it?