### PR TITLE
OpusFormat: Change step size from 2 kbps to 21 kbps

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
@@ -11,7 +11,7 @@ object OpusFormat : Format() {
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.Bitrate,
         6_000u..510_000u,
-        2_000u,
+        21_000u,
         // "Essentially transparent mono or stereo speech, reasonable music"
         // https://wiki.hydrogenaud.io/index.php?title=Opus
         48_000u,


### PR DESCRIPTION
This reduces the number of steps from an excessive 253 steps to 25 steps.

Issue: #237