### PR TITLE
OutputFormatBottomSheetFragment: Remove workaround for material3 bug

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/OutputFormatBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputFormatBottomSheetFragment.kt
@@ -132,14 +132,6 @@ class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
             }
             NoParamInfo -> {
                 binding.paramGroup.isVisible = false
-
-                // Needed due to a bug in the material3 library where the slider label does not disappear
-                // when the slider visibility is set to View.GONE
-                // https://github.com/material-components/material-components-android/issues/2726
-                val ensureLabelsRemoved = binding.paramSlider.javaClass.superclass
-                    .getDeclaredMethod("ensureLabelsRemoved")
-                ensureLabelsRemoved.isAccessible = true
-                ensureLabelsRemoved.invoke(binding.paramSlider)
             }
         }
     }


### PR DESCRIPTION
This fixes a crash due to `NoSuchMethodException` when switching to an output format that does not specify a parameter (bitrate or compression level). The workaround is no longer necessary now that the material3 bug has been fixed and we've upgraded to a release containing the fix in commit 3b0999ac1e3424047e44acf52efc2e17f7257415.

Fixes: #240