### PR TITLE
Notifications.kt: Set persistent notifications' default priority to high

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -73,12 +73,12 @@ class Notifications(
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
 
     /**
-     * Create a low priority notification channel for the persistent notification.
+     * Create a high priority notification channel for the persistent notification.
      */
     private fun createPersistentChannel() = NotificationChannel(
         CHANNEL_ID_PERSISTENT,
         context.getString(R.string.notification_channel_persistent_name),
-        NotificationManager.IMPORTANCE_LOW,
+        NotificationManager.IMPORTANCE_HIGH,
     ).apply {
         description = context.getString(R.string.notification_channel_persistent_desc)
     }


### PR DESCRIPTION
This makes the pause/resume button more visible since high priority notifications are expanded by default (as long as it's the top notification). This only affects new installs and the user's configuration in Android's settings always has precedence.

Fixes: #248