### PR TITLE
magisk: Try to install to a non-overlayfs location

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -304,13 +304,13 @@ android.applicationVariants.all {
         from(moduleProp.map { it.outputs })
         from(addonD.map { it.outputs }) {
             fileMode = 0b111_101_101 // 0o755; kotlin doesn't support octal literals
-            into("system/addon.d")
+            into("overlay/addon.d")
         }
         from(permissionsXml.map { it.outputs }) {
-            into("system/etc/permissions")
+            into("overlay/etc/permissions")
         }
         from(variant.outputs.map { it.outputFile }) {
-            into("system/priv-app/${variant.applicationId}")
+            into("overlay/priv-app/${variant.applicationId}")
         }
 
         val magiskDir = File(projectDir, "magisk")
@@ -320,6 +320,8 @@ android.applicationVariants.all {
                 into("META-INF/com/google/android")
             }
         }
+
+        from(File(magiskDir, "customize.sh"))
 
         from(File(rootDir, "LICENSE"))
         from(File(rootDir, "README.md"))

--- a/app/magisk/customize.sh
+++ b/app/magisk/customize.sh
@@ -1,0 +1,48 @@
+# Until Magisk supports overlayfs, we'll try to install to a non-overlayfs path
+# that still supports privileged apps.
+# https://github.com/topjohnwu/Magisk/pull/6588
+
+has_overlays() {
+    local mnt="${1}" count
+    count=$(awk -v mnt="${mnt}" '$9 == "overlay" && $5 ~ mnt' /proc/self/mountinfo | wc -l)
+    [ "${count}" -gt 0 ]
+}
+
+module_overlay_dir=
+
+for candidate in \
+    /system::system \
+    /product::system/product \
+    /system_ext::system/system_ext \
+    /vendor::system/vendor
+do
+    mountpoint=${candidate%::*}
+
+    if has_overlays "^${mountpoint}"; then
+        echo "Cannot use ${mountpoint}: contains overlayfs mounts"
+    # Magisk fails to mount files when the parent directory does not exist
+    elif [ ! -d "${mountpoint}/etc/permissions" ]; then
+        echo "Cannot use ${mountpoint}: etc/permissions/ does not exist"
+    elif [ ! -d "${mountpoint}/priv-app" ]; then
+        echo "Cannot use ${mountpoint}: priv-app/ does not exist"
+    else
+        echo "Using ${mountpoint} as the installation target"
+        module_overlay_dir=${candidate#*::}
+        break
+    fi
+done
+
+if [ -z "${module_overlay_dir}" ]; then
+    echo 'No suitable installation target found'
+    echo 'This OS is not supported'
+    rm -rv "${MODPATH}" 2>&1
+    exit 1
+fi
+
+if [ "${module_overlay_dir}" != system ]; then
+    echo 'Removing addon.d script since installation target is not /system'
+    rm -rv "${MODPATH}/overlay/addon.d" 2>&1 || exit 1
+fi
+
+mkdir -vp "$(dirname "${MODPATH}/${module_overlay_dir}")" 2>&1 || exit 1
+mv -v "${MODPATH}/overlay" "${MODPATH}/${module_overlay_dir}" 2>&1 || exit 1


### PR DESCRIPTION
Magisk currently has a known issue where its mirror mount points do not work correctly with overlayfs. Files from the overlayfs lowerdirs may no longer be accessible.

On MIUI, this is a problem because /system/etc/permissions is an overlayfs mount and one of the lowerdirs is
/product/pango/system/etc/permissions. One file underneath that path is com.nxp.nfc.nq.xml, which if missing, breaks NFC.

Fixes: #242
Fixes: #246