### PR TITLE
Fix direct installation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -304,13 +304,13 @@ android.applicationVariants.all {
         from(moduleProp.map { it.outputs })
         from(addonD.map { it.outputs }) {
             fileMode = 0b111_101_101 // 0o755; kotlin doesn't support octal literals
-            into("overlay/addon.d")
+            into("system/addon.d")
         }
         from(permissionsXml.map { it.outputs }) {
-            into("overlay/etc/permissions")
+            into("system/etc/permissions")
         }
         from(variant.outputs.map { it.outputFile }) {
-            into("overlay/priv-app/${variant.applicationId}")
+            into("system/priv-app/${variant.applicationId}")
         }
 
         val magiskDir = File(projectDir, "magisk")


### PR DESCRIPTION
The update-binary expects the files to be in system/ for direct installation. This commit renames overlay/ back to system/ and adjusts customize.sh accordingly.

Fixes: #253