### PR TITLE
RecorderThread: Never clear redactions

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -134,8 +134,6 @@ class RecorderThread(
 
             lastCallDetails = details
 
-            redactions.clear()
-
             filename = filenameTemplate.evaluate {
                 when {
                     it == "date" || it.startsWith("date:") -> {


### PR DESCRIPTION
Otherwise, if the caller ID or contact name changes during the middle of the call, we might leak that information in the log file during rename.