### PR TITLE
app/proguard-rules.pro: Keep TreeDocumentFile constructor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,7 +138,23 @@ android {
         }
     }
     buildTypes {
+        getByName("debug") {
+            buildConfigField("boolean", "FORCE_DEBUG_MODE", "true")
+        }
+
+        create("debugOpt") {
+            buildConfigField("boolean", "FORCE_DEBUG_MODE", "true")
+
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+
+            signingConfig = signingConfigs.getByName("debug")
+        }
+
         getByName("release") {
+            buildConfigField("boolean", "FORCE_DEBUG_MODE", "false")
+
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,3 +23,9 @@
 # Disable obfuscation completely for BCR. As an open source project,
 # shrinking is the only goal of minification.
 -dontobfuscate
+
+# We construct TreeDocumentFile via reflection in DocumentFileExtensions
+# to speed up SAF performance when doing path lookups.
+-keepclassmembers class androidx.documentfile.provider.TreeDocumentFile {
+    <init>(androidx.documentfile.provider.DocumentFile, android.content.Context, android.net.Uri);
+}

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -70,7 +70,7 @@ class Preferences(private val context: Context) {
     }
 
     var isDebugMode: Boolean
-        get() = prefs.getBoolean(PREF_DEBUG_MODE, false)
+        get() = BuildConfig.FORCE_DEBUG_MODE || prefs.getBoolean(PREF_DEBUG_MODE, false)
         set(enabled) = prefs.edit { putBoolean(PREF_DEBUG_MODE, enabled) }
 
     /**

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -52,7 +52,7 @@ class RecorderThread(
 ) : Thread(RecorderThread::class.java.simpleName) {
     private val tag = "${RecorderThread::class.java.simpleName}/${id}"
     private val prefs = Preferences(context)
-    private val isDebug = BuildConfig.DEBUG || prefs.isDebugMode
+    private val isDebug = prefs.isDebugMode
 
     // Thread state
     @Volatile private var isCancelled = false

--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -125,7 +125,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun refreshVersion() {
-            val suffix = if (!BuildConfig.DEBUG && prefs.isDebugMode) {
+            val suffix = if (prefs.isDebugMode) {
                 "+debugmode"
             } else {
                 ""


### PR DESCRIPTION
We call it via reflection in our faster DocumentFile extensions and the first parameter was being optimized out in release builds because it is always null in the usages that R8 is able to analyze.

Related-to: #257
Fixes: #260