### PR TITLE
Improve conference call handling

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -25,7 +25,7 @@ object Permissions {
         Manifest.permission.READ_PHONE_STATE,
     )
 
-    private fun isGranted(context: Context, permission: String) =
+    fun isGranted(context: Context, permission: String) =
         ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 
     /**

--- a/app/src/main/res/raw/filename_template.properties
+++ b/app/src/main/res/raw/filename_template.properties
@@ -43,7 +43,8 @@
 # timestamps in the filenames to have the expected pattern.
 filename.0.text = ${date}
 
-# Call direction, which is either `in` or `out`. Only defined on Android 10+.
+# Call direction, which can be `in`, `out`, or `conference`. Only defined on
+# Android 10+.
 filename.1.text = ${direction}
 filename.1.prefix = _
 
@@ -60,8 +61,7 @@ filename.3.prefix = _
 filename.4.text = ${caller_name}
 filename.4.prefix = _
 
-# Contact name. Only defined on Android 11+ if the user has granted the contacts
-# permission.
+# Contact name. Only defined if the user has granted the contacts permission.
 filename.5.text = ${contact_name}
 filename.5.prefix = _
 


### PR DESCRIPTION
* RecorderInCallService and RecorderThread have been updated to be aware of parent/child relationships of calls. Previously, child calls were treated as independent calls, so a conference call would result in separate (but identical in audio) recordings for the parent conference call and every call it was merged from.
* RecorderInCallService and RecorderThread now trim out sections of the recording where the call is in the HOLDING state. This prevents audio from a different call from being recorded while the call is on hold (due to call waiting).
* RecorderThread now performs a manual contact lookup if the Android telephony framework does not provide the contact display name. This is common in conference calls and is likely a bug in AOSP. As a side effect, contact lookup now works in all supported Android versions instead of just 11+.

Issue: #284