### PR TITLE
DocumentFileExtensions.kt: Use simple string operations to preserve extension when renaming

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/DocumentFileExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/DocumentFileExtensions.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.net.Uri
 import android.provider.DocumentsContract
 import android.util.Log
-import android.webkit.MimeTypeMap
 import androidx.documentfile.provider.DocumentFile
 
 private const val TAG = "DocumentFileExtensions"
@@ -112,8 +111,12 @@ fun DocumentFile.renameToPreserveExt(displayName: String): Boolean {
             buildString {
                 append(displayName)
 
-                val ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(type)
-                if (ext != null) {
+                // This intentionally just does simple string operations because MimeTypeMap's
+                // getExtensionFromMimeType() and getMimeTypeFromExtension() are not consistent with
+                // each other. Eg. audio/mp4 -> m4a -> audio/mpeg -> mp3.
+
+                val ext = name!!.substringAfterLast('.', "")
+                if (ext.isNotEmpty()) {
                     append('.')
                     append(ext)
                 }


### PR DESCRIPTION
`MimeTypeMap`'s `getExtensionFromMimeType()` and `getMimeTypeFromExtension()` are not consistent with each other. Querying the extension for `audio/mp4` returns `m4a` as expected, but querying the MIME type for `m4a` returns `audio/mpeg`, which is associated with the `mp3` extension.

Due to this, whenever an output file needed to be renamed, files that originally had the `m4a` extension would get changed to `mp3`. This commit fixes the issue by removing the whole extension -> MIME type -> extension round trip when renaming files. Instead, it just appends everything after the last dot from the original filename when renaming.

Fixes: #292