### PR TITLE
app/build.gradle.kts: Avoid calling deprecated Thread.getId()

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -207,7 +207,7 @@ val archive = tasks.register("archive") {
     outputs.file(outputFile)
 
     doLast {
-        val format = "tar_${Thread.currentThread().id}"
+        val format = "tar_for_task_$name"
 
         ArchiveCommand.registerFormat(format, TarFormat())
         try {


### PR DESCRIPTION
The method was deprecated in JDK 19. For uniqueness of the name given to ArchiveCommand.registerFormat(), we can just use the task name instead. Two instances of the same task will never run concurrently.

Issue: #294