### PR TITLE
Add support for looking up the cached name in the call log

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
 
 4. Enable call recording and pick an output directory. If no output directory is selected or if the output directory is no longer accessible, then recordings will be saved to `/sdcard/Android/data/com.chiller3.bcr/files`.
 
-    When enabling call recording the first time, BCR will prompt for microphone, notification (Android 13+), contacts, and phone permissions. Only microphone and notification permissions are required basic call recording functionality. If additional permissions are granted, more information is added to the output filename. For example, the contacts permission will cause the contact name to be added to the filename and the phone permission will cause the SIM slot (if multiple SIMs are active) to be added to the filename.
+    When enabling call recording the first time, BCR will prompt for microphone, notification (Android 13+), call log, contacts, and phone permissions. Only microphone and notification permissions are required basic call recording functionality. If additional permissions are granted, more information is added to the output filename. For example, the contacts permission will allow the contact name to be added to the filename.
 
     See the [permissions section](#permissions) below for more details about the permissions.
 
@@ -73,8 +73,10 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
 * `POST_NOTIFICATIONS` (**must be granted by the user on Android 13+**)
   * Needed to show notifications.
   * A notification is required for running the call recording service in foreground mode or else Android will not allow access to the call audio stream.
+* `READ_CALL_LOG` (**optional**)
+  * If allowed, the name as shown in the call log can be added to the output filename.
 * `READ_CONTACTS` (**optional**)
-  * If allowed, the contact name is added to the output filename.
+  * If allowed, the contact name can be added to the output filename.
 * `READ_PHONE_STATE` (**optional**)
   * If allowed, the SIM slot for devices with multiple active SIMs is added to the output filename.
 * `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (**optional**)
@@ -91,7 +93,7 @@ Note that `INTERNET` is _not_ in the list. BCR does not and will never access th
 BCR supports customizing the template used for determining the output filenames of recordings. The default template is:
 
 ```
-{date}[_{direction}|][_sim{sim_slot}|][_{phone_number}|][_[{contact_name}|{caller_name}]|]
+{date}[_{direction}|][_sim{sim_slot}|][_{phone_number}|][_[{contact_name}|{caller_name}|{call_log_name}]|]
 ```
 
 ### Template syntax
@@ -109,6 +111,7 @@ BCR supports customizing the template used for determining the output filenames 
 * `{phone_number}`: The phone number for the call. This is undefined for private calls.
 * `{caller_name}`: The caller ID as provided by CNAP from the carrier.
 * `{contact_name}` The name of the (first) contact associated with the phone number. This is only defined if BCR is granted the Contacts permission.
+* `{call_log_name}`: The name shown in the call log. This may include more information, like the name of the business, if the system dialer performs reverse lookups. This is only defined if BCR is granted the Read Call Logs permission.
 
 ## Advanced features
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -21,6 +21,7 @@ object Permissions {
 
     val REQUIRED: Array<String> = arrayOf(Manifest.permission.RECORD_AUDIO) + NOTIFICATION
     val OPTIONAL: Array<String> = arrayOf(
+        Manifest.permission.READ_CALL_LOG,
         Manifest.permission.READ_CONTACTS,
         Manifest.permission.READ_PHONE_STATE,
     )

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -37,7 +37,7 @@ class Preferences(private val context: Context) {
                     "[_{direction}|]" +
                     "[_sim{sim_slot}|]" +
                     "[_{phone_number}|]" +
-                    "[_[{contact_name}|{caller_name}]|]"
+                    "[_[{contact_name}|{caller_name}|{call_log_name}]|]"
         )
 
         fun isFormatKey(key: String): Boolean =


### PR DESCRIPTION
This commit adds a new `{call_log_name}` variable that can be used in the filename template for including the call log cached name. The cache name may be updated by the system dialer to include the name of the business assocciated with the phone number.

This new variable is added to the default filename template, but only as a last resort because it relies on polling for up to 2 seconds after the call completes.

Fixes: #291