### PR TITLE
Validate arguments when editing filename template

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
@@ -71,15 +71,6 @@ class FilenameTemplateDialogFragment : DialogFragment() {
 
                         // Only show first error due to space constraints
                         val error = errors.first()
-                        val varRefDisplay = buildString {
-                            append('{')
-                            append(error.name)
-                            if (error.arg != null) {
-                                append(':')
-                                append(error.arg)
-                            }
-                            append('}')
-                        }
 
                         val errorResId = when (error.type) {
                             OutputFilenameGenerator.ValidationErrorType.UNKNOWN_VARIABLE -> {
@@ -93,7 +84,7 @@ class FilenameTemplateDialogFragment : DialogFragment() {
                             }
                         }
                         binding.textLayout.error = buildErrorMessageWithTemplate(
-                            errorResId, varRefDisplay)
+                            errorResId, error.varRef.toTemplate())
                     }
                 } catch (e: Exception) {
                     template = null
@@ -148,7 +139,7 @@ class FilenameTemplateDialogFragment : DialogFragment() {
                 var nextOffset = start
 
                 for ((i, v) in OutputFilenameGenerator.KNOWN_VARS.withIndex()) {
-                    val text = "{$v}"
+                    val text = Template.VariableRef(v, null).toTemplate()
 
                     if (i == 0) {
                         message.replace(start, end, text)

--- a/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
@@ -14,6 +14,7 @@ import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.TypefaceSpan
 import android.view.View
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
@@ -57,26 +58,47 @@ class FilenameTemplateDialogFragment : DialogFragment() {
                 binding.textLayout.error = getString(R.string.filename_template_dialog_error_empty)
             } else {
                 try {
-                    template = Template(it.toString()).apply {
-                        evaluate { name, _ ->
-                            if (name in OutputFilenameGenerator.KNOWN_VARS) {
-                                ""
-                            } else {
-                                null
+                    val newTemplate = Template(it.toString())
+                    val errors = OutputFilenameGenerator.validate(newTemplate)
+                    if (errors.isEmpty()) {
+                        template = newTemplate
+
+                        binding.textLayout.error = null
+                        // Don't keep the layout space for the error message reserved
+                        binding.textLayout.isErrorEnabled = false
+                    } else {
+                        template = null
+
+                        // Only show first error due to space constraints
+                        val error = errors.first()
+                        val varRefDisplay = buildString {
+                            append('{')
+                            append(error.name)
+                            if (error.arg != null) {
+                                append(':')
+                                append(error.arg)
+                            }
+                            append('}')
+                        }
+
+                        val errorResId = when (error.type) {
+                            OutputFilenameGenerator.ValidationErrorType.UNKNOWN_VARIABLE -> {
+                                R.string.filename_template_dialog_error_unknown_variable
+                            }
+                            OutputFilenameGenerator.ValidationErrorType.HAS_ARGUMENT -> {
+                                R.string.filename_template_dialog_error_has_argument
+                            }
+                            OutputFilenameGenerator.ValidationErrorType.INVALID_ARGUMENT -> {
+                                R.string.filename_template_dialog_error_invalid_argument
                             }
                         }
+                        binding.textLayout.error = buildErrorMessageWithTemplate(
+                            errorResId, varRefDisplay)
                     }
-                    binding.textLayout.error = null
-                    // Don't keep the layout space for the error message reserved
-                    binding.textLayout.isErrorEnabled = false
-                } catch (e: Template.MissingVariableException) {
-                    template = null
-                    binding.textLayout.error =
-                        getString(R.string.filename_template_dialog_error_unknown_var, e.name)
                 } catch (e: Exception) {
                     template = null
                     binding.textLayout.error =
-                        getString(R.string.filename_template_dialog_error_invalid)
+                        getString(R.string.filename_template_dialog_error_invalid_syntax)
                 }
             }
 
@@ -163,6 +185,39 @@ class FilenameTemplateDialogFragment : DialogFragment() {
                     end,
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
                 )
+            } else {
+                throw IllegalStateException("Invalid annotation: $annotation")
+            }
+        }
+
+        return message
+    }
+
+    private fun buildErrorMessageWithTemplate(
+        @StringRes stringResId: Int,
+        template: String,
+    ): SpannableStringBuilder {
+        val origMessage = getText(stringResId) as SpannedString
+        val message = SpannableStringBuilder(origMessage)
+        val annotations = message.getSpans(0, origMessage.length, Annotation::class.java)
+
+        for (annotation in annotations) {
+            val start = message.getSpanStart(annotation)
+            val end = message.getSpanEnd(annotation)
+
+            if (annotation.key == "type" && annotation.value == "template") {
+                message.replace(start, end, template)
+
+                val newEnd = start + template.length
+
+                message.setSpan(
+                    TypefaceSpan(Typeface.MONOSPACE),
+                    start,
+                    newEnd,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+
+                highlighter.highlight(message, start, newEnd)
             } else {
                 throw IllegalStateException("Invalid annotation: $annotation")
             }

--- a/app/src/main/java/com/chiller3/bcr/OutputDirectoryBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputDirectoryBottomSheetFragment.kt
@@ -95,7 +95,7 @@ class OutputDirectoryBottomSheetFragment : BottomSheetDialogFragment(), Slider.O
         val template = prefs.filenameTemplate ?: Preferences.DEFAULT_FILENAME_TEMPLATE
         val locations = template.findVariableRef(OutputFilenameGenerator.DATE_VAR)
         binding.retentionSlider.isEnabled = locations != null &&
-                locations.third != setOf(Template.VariableRefLocation.Arbitrary)
+                locations.second != setOf(Template.VariableRefLocation.Arbitrary)
     }
 
     override fun onValueChange(slider: Slider, value: Float, fromUser: Boolean) {

--- a/app/src/main/java/com/chiller3/bcr/Template.kt
+++ b/app/src/main/java/com/chiller3/bcr/Template.kt
@@ -482,4 +482,33 @@ class Template(template: String) {
 
         return Triple(varRef.name, varRef.arg, locations)
     }
+
+    /**
+     * Find every variable reference in the template. This includes ones that may not be evaluated
+     * by [evaluate] due to being in later fallback choices.
+     */
+    fun findAllVariableRefs(): List<Pair<String, String?>> {
+        val refs = mutableListOf<Pair<String, String?>>()
+
+        fun recurse(node: AstNode) {
+            when (node) {
+                is StringLiteral -> {}
+                is VariableRef -> refs.add(Pair(node.name, node.arg))
+                is Fallback -> {
+                    for (choice in node.choices) {
+                        recurse(choice)
+                    }
+                }
+                is TemplateString -> {
+                    for (clause in node.clauses) {
+                        recurse(clause)
+                    }
+                }
+            }
+        }
+
+        recurse(parsed.first.value)
+
+        return refs
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,8 +50,10 @@
     <!-- NOTE: For the "supported_vars" annotation, the content MUST not be empty. Any string can go inside of it as a placeholder. -->
     <string name="filename_template_dialog_message">Enter a custom template for the output filename. Variables are specified with curly braces (eg. <annotation type="template">{var}</annotation>). Fallbacks are specified with square brackets (eg. <annotation type="template">[{contact_name}|Unknown]</annotation>).\n\nSupported variables: <annotation type="supported_vars">PLACEHOLDER</annotation>. See <annotation type="template_docs">the documentation</annotation> for a complete description of the syntax.</string>
     <string name="filename_template_dialog_error_empty">Template cannot be empty</string>
-    <string name="filename_template_dialog_error_unknown_var">Unknown template variable: %s</string>
-    <string name="filename_template_dialog_error_invalid">Template syntax is invalid</string>
+    <string name="filename_template_dialog_error_unknown_variable">Unknown template variable: <annotation type="template">PLACEHOLDER</annotation></string>
+    <string name="filename_template_dialog_error_has_argument">Variable cannot have an argument: <annotation type="template">PLACEHOLDER</annotation></string>
+    <string name="filename_template_dialog_error_invalid_argument">Invalid variable argument: <annotation type="template">PLACEHOLDER</annotation></string>
+    <string name="filename_template_dialog_error_invalid_syntax">Template syntax is invalid</string>
     <string name="filename_template_dialog_action_reset_to_default">Reset to default</string>
 
     <!-- Dialogs -->

--- a/app/src/test/java/com/chiller3/bcr/TemplateTest.kt
+++ b/app/src/test/java/com/chiller3/bcr/TemplateTest.kt
@@ -350,34 +350,67 @@ class TemplateTest {
     @Test
     fun testFindVariableRef() {
         assertEquals(
-            Triple("var", null, setOf(
-                Template.VariableRefLocation.AfterPrefix("foo", true),
-            )),
+            Pair(
+                Template.VariableRef("var", null),
+                setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
+            ),
             Template("foo{var}").findVariableRef("var"),
         )
         assertEquals(
-            Triple("var", null, setOf(
-                Template.VariableRefLocation.AfterPrefix("foo", true),
-            )),
+            Pair(
+                Template.VariableRef("var", null),
+                setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
+            ),
             Template("[]foo{var}").findVariableRef("var"),
         )
         assertEquals(
-            Triple("var", null, setOf(
-                Template.VariableRefLocation.AfterPrefix("foo", true),
-            )),
+            Pair(
+                Template.VariableRef("var", null),
+                setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
+            ),
             Template("foo[]{var}").findVariableRef("var"),
         )
         assertEquals(
-            Triple("var", "arg", setOf(
-                Template.VariableRefLocation.AfterPrefix("", true),
-            )),
+            Pair(
+                Template.VariableRef("var", "arg"),
+                setOf(Template.VariableRefLocation.AfterPrefix("", true)),
+            ),
             Template("{var:arg}").findVariableRef("var"),
         )
         assertEquals(
-            Triple("date", null, setOf(
-                Template.VariableRefLocation.AfterPrefix("", true),
-            )),
+            Pair(
+                Template.VariableRef("date", null),
+                setOf(Template.VariableRefLocation.AfterPrefix("", true)),
+            ),
             Preferences.DEFAULT_FILENAME_TEMPLATE.findVariableRef("date"),
+        )
+    }
+
+    @Test
+    fun testAllFindVariableRef() {
+        assertEquals(
+            listOf(Template.VariableRef("var", null)),
+            Template("{var}").findAllVariableRefs(),
+        )
+        assertEquals(
+            listOf(
+                Template.VariableRef("a", null),
+                Template.VariableRef("b", null),
+            ),
+            Template("[{a}|{b}]").findAllVariableRefs(),
+        )
+        assertEquals(
+            listOf(
+                Template.VariableRef("a", null),
+                Template.VariableRef("b", null),
+                Template.VariableRef("c", null),
+                Template.VariableRef("d", "arg"),
+            ),
+            Template("[{a}|{b}]{c}[[{d:arg}]]").findAllVariableRefs(),
+        )
+        assertEquals(
+            OutputFilenameGenerator.KNOWN_VARS.map { Template.VariableRef(it, null) },
+            Preferences.DEFAULT_FILENAME_TEMPLATE.findAllVariableRefs(),
         )
     }
 }


### PR DESCRIPTION
Instead of performing a test evaluation, which can miss fallback choices, we instead query the entire template AST for all variable ref nodes. For each of the nodes, we check that both the name and argument are valid.

(The error messages have syntax highlighting too!)