### PR TITLE
Replace format parameter slider with chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add support for querying the name from the call log (Issue: #291, PR: #298, @chenxiaolong)
   * This requires the optional `READ_CALL_LOGS` permission to be granted.
 * Add support for formatting the phone number as digits only or with the country-specific style (Issue: #290, PR: #299, @chenxiaolong)
+* Replace slider UI components with chips and the ability to set custom values (Issue: #295, PR: #301, @chenxiaolong)
 
 Non-user-facing changes:
 

--- a/app/src/main/java/com/chiller3/bcr/FileRetentionDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FileRetentionDialogFragment.kt
@@ -1,0 +1,99 @@
+package com.chiller3.bcr
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.InputType
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.bcr.databinding.DialogTextInputBinding
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class FileRetentionDialogFragment : DialogFragment() {
+    companion object {
+        val TAG: String = FileRetentionDialogFragment::class.java.simpleName
+
+        const val RESULT_SUCCESS = "success"
+    }
+
+    private lateinit var prefs: Preferences
+    private lateinit var binding: DialogTextInputBinding
+    private var retention: Retention? = null
+    private var success: Boolean = false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = requireContext()
+        prefs = Preferences(context)
+        retention = Retention.fromPreferences(prefs)
+
+        binding = DialogTextInputBinding.inflate(layoutInflater)
+
+        binding.message.setText(R.string.file_retention_dialog_message)
+
+        binding.text.inputType = InputType.TYPE_CLASS_NUMBER
+        binding.text.addTextChangedListener {
+            retention = if (it!!.isEmpty()) {
+                NoRetention
+            } else {
+                try {
+                    val days = it.toString().toUInt()
+                    if (days == 0U) {
+                        NoRetention
+                    } else {
+                        DaysRetention(days)
+                    }
+                } catch (e: NumberFormatException) {
+                    binding.textLayout.error = getString(R.string.file_retention_error_too_large)
+                    null
+                }
+            }
+
+            refreshHelperText()
+            refreshOkButtonEnabledState()
+        }
+        if (savedInstanceState == null) {
+            when (val r = retention!!) {
+                is DaysRetention -> binding.text.setText(r.days.toString())
+                NoRetention -> binding.text.setText("")
+            }
+        }
+
+        refreshHelperText()
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.file_retention_dialog_title)
+            .setView(binding.root)
+            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+                prefs.outputRetention = retention!!
+                success = true
+            }
+            .setNegativeButton(R.string.dialog_action_cancel, null)
+            .create()
+            .apply {
+                setCanceledOnTouchOutside(false)
+            }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        refreshOkButtonEnabledState()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+
+    private fun refreshHelperText() {
+        binding.textLayout.helperText = retention?.toFormattedString(requireContext())
+    }
+
+    private fun refreshOkButtonEnabledState() {
+        (dialog as AlertDialog?)?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
+            retention != null
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
@@ -99,7 +99,7 @@ class FilenameTemplateDialogFragment : DialogFragment() {
             refreshOkButtonEnabledState()
         }
         if (savedInstanceState == null) {
-            binding.text.setText(template.toString())
+            binding.text.setText(template!!.toString())
         }
 
         return MaterialAlertDialogBuilder(requireContext())
@@ -112,6 +112,7 @@ class FilenameTemplateDialogFragment : DialogFragment() {
             .setNegativeButton(R.string.dialog_action_cancel, null)
             .setNeutralButton(R.string.filename_template_dialog_action_reset_to_default) { _, _ ->
                 prefs.filenameTemplate = null
+                success = true
             }
             .create()
             .apply {

--- a/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
@@ -98,7 +98,9 @@ class FilenameTemplateDialogFragment : DialogFragment() {
 
             refreshOkButtonEnabledState()
         }
-        binding.text.setText(template.toString())
+        if (savedInstanceState == null) {
+            binding.text.setText(template.toString())
+        }
 
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.filename_template_dialog_title)

--- a/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FilenameTemplateDialogFragment.kt
@@ -7,6 +7,7 @@ import android.graphics.Typeface
 import android.net.Uri
 import android.os.Bundle
 import android.text.Annotation
+import android.text.InputType
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.SpannedString
@@ -20,7 +21,7 @@ import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
-import com.chiller3.bcr.databinding.DialogFilenameTemplateBinding
+import com.chiller3.bcr.databinding.DialogTextInputBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class FilenameTemplateDialogFragment : DialogFragment() {
@@ -32,7 +33,7 @@ class FilenameTemplateDialogFragment : DialogFragment() {
 
     private lateinit var prefs: Preferences
     private lateinit var highlighter: TemplateSyntaxHighlighter
-    private lateinit var binding: DialogFilenameTemplateBinding
+    private lateinit var binding: DialogTextInputBinding
     private var template: Template? = null
     private var success: Boolean = false
 
@@ -42,11 +43,13 @@ class FilenameTemplateDialogFragment : DialogFragment() {
         highlighter = TemplateSyntaxHighlighter(context)
         template = prefs.filenameTemplate ?: Preferences.DEFAULT_FILENAME_TEMPLATE
 
-        binding = DialogFilenameTemplateBinding.inflate(layoutInflater)
+        binding = DialogTextInputBinding.inflate(layoutInflater)
 
         binding.message.movementMethod = LinkMovementMethod.getInstance()
         binding.message.text = buildMessage()
 
+        binding.text.inputType = InputType.TYPE_CLASS_TEXT or
+                InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
         // Make this non-multiline text box look like one
         binding.text.setHorizontallyScrolling(false)
         binding.text.maxLines = Int.MAX_VALUE

--- a/app/src/main/java/com/chiller3/bcr/FormatParamDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/FormatParamDialogFragment.kt
@@ -1,0 +1,104 @@
+package com.chiller3.bcr
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.InputType
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.bcr.databinding.DialogTextInputBinding
+import com.chiller3.bcr.format.Format
+import com.chiller3.bcr.format.RangedParamInfo
+import com.chiller3.bcr.format.RangedParamType
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class FormatParamDialogFragment : DialogFragment() {
+    companion object {
+        val TAG: String = FormatParamDialogFragment::class.java.simpleName
+
+        const val RESULT_SUCCESS = "success"
+    }
+
+    private lateinit var prefs: Preferences
+    private lateinit var format: Format
+    private lateinit var binding: DialogTextInputBinding
+    private var value: UInt? = null
+    private var success: Boolean = false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = requireContext()
+        prefs = Preferences(context)
+        format = Format.fromPreferences(prefs).first
+
+        val paramInfo = format.paramInfo
+        if (paramInfo !is RangedParamInfo) {
+            throw IllegalStateException("Selected format is not configurable")
+        }
+
+        val multiplier = when (paramInfo.type) {
+            RangedParamType.CompressionLevel -> 1U
+            RangedParamType.Bitrate -> 1000U
+        }
+
+        binding = DialogTextInputBinding.inflate(layoutInflater)
+
+        binding.message.text = getString(
+            R.string.format_param_dialog_message,
+            paramInfo.format(paramInfo.range.first),
+            paramInfo.format(paramInfo.range.last),
+        )
+
+        if (paramInfo.type == RangedParamType.Bitrate) {
+            binding.textLayout.suffixText = "kbps"
+            binding.text.textAlignment = View.TEXT_ALIGNMENT_TEXT_END
+        }
+
+        binding.text.inputType = InputType.TYPE_CLASS_NUMBER
+        binding.text.addTextChangedListener {
+            value = if (it!!.isNotEmpty()) {
+                val newValue = it.toString().toUInt().times(multiplier.toULong())
+                if (newValue in paramInfo.range) {
+                    newValue.toUInt()
+                } else {
+                    null
+                }
+            } else {
+                null
+            }
+
+            refreshOkButtonEnabledState()
+        }
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.format_param_dialog_title)
+            .setView(binding.root)
+            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+                prefs.setFormatParam(format, value!!)
+                success = true
+            }
+            .setNegativeButton(R.string.dialog_action_cancel, null)
+            .create()
+            .apply {
+                setCanceledOnTouchOutside(false)
+            }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        refreshOkButtonEnabledState()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+
+    private fun refreshOkButtonEnabledState() {
+        (dialog as AlertDialog?)?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = value != null
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/OutputFormatBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputFormatBottomSheetFragment.kt
@@ -100,7 +100,7 @@ class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
             chipBinding.root.setOnCloseIconClickListener(::onChipClosed)
         }
         if (value != null) {
-            chipBinding.root.text = paramInfo.format(value)
+            chipBinding.root.text = paramInfo.format(requireContext(), value)
         } else {
             chipBinding.root.setText(R.string.output_format_bottom_sheet_custom_param)
         }

--- a/app/src/main/java/com/chiller3/bcr/OutputFormatBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputFormatBottomSheetFragment.kt
@@ -16,10 +16,7 @@ import com.google.android.material.chip.ChipGroup
 
 class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
     ChipGroup.OnCheckedStateChangeListener, View.OnClickListener {
-    private var _binding: OutputFormatBottomSheetBinding? = null
-    private val binding
-        get() = _binding!!
-
+    private lateinit var binding: OutputFormatBottomSheetBinding
     private lateinit var prefs: Preferences
 
     private val chipIdToFormat = HashMap<Int, Format>()
@@ -36,7 +33,7 @@ class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = OutputFormatBottomSheetBinding.inflate(inflater, container, false)
+        binding = OutputFormatBottomSheetBinding.inflate(inflater, container, false)
 
         prefs = Preferences(requireContext())
 
@@ -69,11 +66,6 @@ class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
         refreshSampleRate()
 
         return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun addChip(inflater: LayoutInflater, parent: ViewGroup): BottomSheetChipBinding {
@@ -192,7 +184,7 @@ class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
                 }
             }
             binding.sampleRateGroup -> {
-                prefs.sampleRate = chipIdToSampleRate[checkedIds.first()]
+                prefs.sampleRate = chipIdToSampleRate[checkedIds.first()]!!
             }
         }
     }

--- a/app/src/main/java/com/chiller3/bcr/Retention.kt
+++ b/app/src/main/java/com/chiller3/bcr/Retention.kt
@@ -9,16 +9,7 @@ sealed interface Retention {
     fun toRawPreferenceValue(): UInt
 
     companion object {
-        val all = arrayOf(
-            DaysRetention(1u),
-            DaysRetention(7u),
-            DaysRetention(30u),
-            DaysRetention(90u),
-            DaysRetention(182u),
-            DaysRetention(365u),
-            NoRetention,
-        )
-        val default = all.last()
+        val default = NoRetention
 
         fun fromRawPreferenceValue(value: UInt): Retention = if (value == 0u) {
             NoRetention
@@ -26,21 +17,7 @@ sealed interface Retention {
             DaysRetention(value)
         }
 
-        /**
-         * Get the saved retention in days from the preferences.
-         *
-         * If the saved sample rate is no longer valid or no sample rate is selected, then [default]
-         * is returned.
-         */
-        fun fromPreferences(prefs: Preferences): Retention {
-            val savedRetention = prefs.outputRetention
-
-            if (savedRetention != null && all.contains(savedRetention)) {
-                return savedRetention
-            }
-
-            return default
-        }
+        fun fromPreferences(prefs: Preferences): Retention = prefs.outputRetention ?: default
     }
 }
 
@@ -52,7 +29,7 @@ object NoRetention : Retention {
 }
 
 @JvmInline
-value class DaysRetention(private val days: UInt) : Retention {
+value class DaysRetention(val days: UInt) : Retention {
     override fun toFormattedString(context: Context): String =
         context.resources.getQuantityString(R.plurals.retention_days, days.toInt(), days.toInt())
 

--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -116,7 +116,7 @@ class SettingsActivity : AppCompatActivity() {
             val formatParam = formatParamSaved ?: format.paramInfo.default
             val summary = getString(R.string.pref_output_format_desc)
             val prefix = when (val info = format.paramInfo) {
-                is RangedParamInfo -> "${info.format(formatParam)}, "
+                is RangedParamInfo -> "${info.format(requireContext(), formatParam)}, "
                 NoParamInfo -> ""
             }
             val sampleRate = SampleRate.fromPreferences(prefs)

--- a/app/src/main/java/com/chiller3/bcr/format/AacFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/AacFormat.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package com.chiller3.bcr.format
 
 import android.media.MediaCodecInfo
@@ -14,8 +16,13 @@ object AacFormat : Format() {
         // with AAC-LC: 2 * 64kbps/channel.
         // https://trac.ffmpeg.org/wiki/Encode/AAC
         24_000u..128_000u,
-        4_000u,
         64_000u,
+        uintArrayOf(
+            24_000u,
+            // "As a rule of thumb, for audible transparency, use 64 kBit/s for each channel"
+            64_000u,
+            128_000u,
+        ),
     )
     // https://datatracker.ietf.org/doc/html/rfc6381#section-3.1
     override val mimeTypeContainer: String = "audio/mp4"

--- a/app/src/main/java/com/chiller3/bcr/format/FlacContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/FlacContainer.kt
@@ -1,4 +1,3 @@
-@file:Suppress("OPT_IN_IS_NOT_ENABLED")
 @file:OptIn(ExperimentalUnsignedTypes::class)
 
 package com.chiller3.bcr.format

--- a/app/src/main/java/com/chiller3/bcr/format/FlacFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/FlacFormat.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package com.chiller3.bcr.format
 
 import android.media.MediaFormat
@@ -8,9 +10,9 @@ object FlacFormat : Format() {
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.CompressionLevel,
         0u..8u,
-        1u,
         // Devices are fast enough nowadays to use the highest compression for realtime recording
         8u,
+        uintArrayOf(0u, 5u, 8u),
     )
     override val mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_FLAC
     override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_FLAC

--- a/app/src/main/java/com/chiller3/bcr/format/Format.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/Format.kt
@@ -101,14 +101,14 @@ sealed class Format {
          * The parameter, if set, is clamped to the format's allowed parameter range.
          */
         fun fromPreferences(prefs: Preferences): Pair<Format, UInt?> {
-            // Use the saved format if it is valid and supported on the current device. Otherwise, fall
-            // back to the default.
+            // Use the saved format if it is valid and supported on the current device. Otherwise,
+            // fall back to the default.
             val format = prefs.format
                 ?.let { if (it.supported) { it } else { null } }
                 ?: default
 
-            // Convert the saved value to the nearest valid value (eg. in case bitrate range or step
-            // size in changed in a future version)
+            // Convert the saved value to the nearest valid value (eg. in case the bitrate range is
+            // changed in a future version)
             val param = prefs.getFormatParam(format)?.let {
                 format.paramInfo.toNearest(it)
             }

--- a/app/src/main/java/com/chiller3/bcr/format/FormatParamInfo.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/FormatParamInfo.kt
@@ -2,6 +2,9 @@
 
 package com.chiller3.bcr.format
 
+import android.content.Context
+import com.chiller3.bcr.R
+
 sealed class FormatParamInfo(
     val default: UInt,
     /** Handful of handpicked parameter choices to show in the UI as presets. */
@@ -22,7 +25,7 @@ sealed class FormatParamInfo(
     /**
      * Format [param] to present as a user-facing string.
      */
-    abstract fun format(param: UInt): String
+    abstract fun format(context: Context, param: UInt): String
 }
 
 enum class RangedParamType {
@@ -38,18 +41,20 @@ class RangedParamInfo(
 ) : FormatParamInfo(default, presets) {
     override fun validate(param: UInt) {
         if (param !in range) {
-            throw IllegalArgumentException("Parameter ${format(param)} is not in the range: " +
-                    "[${format(range.first)}, ${format(range.last)}]")
+            throw IllegalArgumentException("Parameter $param is not in the range: " +
+                    "[${range.first}, ${range.last}]")
         }
     }
 
     /** Clamp [param] to [range]. */
     override fun toNearest(param: UInt): UInt = param.coerceIn(range)
 
-    override fun format(param: UInt): String =
+    override fun format(context: Context, param: UInt): String =
         when (type) {
-            RangedParamType.CompressionLevel -> param.toString()
-            RangedParamType.Bitrate -> "${param / 1_000u} kbps"
+            RangedParamType.CompressionLevel ->
+                context.getString(R.string.format_param_compression_level, param.toString())
+            RangedParamType.Bitrate ->
+                context.getString(R.string.format_param_bitrate, (param / 1_000U).toString())
         }
 }
 
@@ -60,5 +65,5 @@ object NoParamInfo : FormatParamInfo(0u, uintArrayOf()) {
 
     override fun toNearest(param: UInt): UInt = param
 
-    override fun format(param: UInt): String = ""
+    override fun format(context: Context, param: UInt): String = ""
 }

--- a/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
 package com.chiller3.bcr.format
 
 import android.media.MediaFormat
@@ -11,10 +13,16 @@ object OpusFormat : Format() {
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.Bitrate,
         6_000u..510_000u,
-        21_000u,
-        // "Essentially transparent mono or stereo speech, reasonable music"
-        // https://wiki.hydrogenaud.io/index.php?title=Opus
         48_000u,
+        // https://wiki.hydrogenaud.io/index.php?title=Opus
+        uintArrayOf(
+            // "Medium bandwidth, better than telephone quality"
+            12_000u,
+            // "Near transparent speech"
+            24_000u,
+            // "Essentially transparent mono or stereo speech, reasonable music"
+            48_000u,
+        ),
     )
     // https://datatracker.ietf.org/doc/html/rfc7845#section-9
     override val mimeTypeContainer: String = "audio/ogg"

--- a/app/src/main/java/com/chiller3/bcr/format/WaveContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/WaveContainer.kt
@@ -1,4 +1,3 @@
-@file:Suppress("OPT_IN_IS_NOT_ENABLED")
 @file:OptIn(ExperimentalUnsignedTypes::class)
 
 package com.chiller3.bcr.format

--- a/app/src/main/res/layout/dialog_text_input.xml
+++ b/app/src/main/res/layout/dialog_text_input.xml
@@ -26,8 +26,7 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/text"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="textNoSuggestions" />
+                android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/output_directory_bottom_sheet.xml
+++ b/app/src/main/res/layout/output_directory_bottom_sheet.xml
@@ -22,7 +22,8 @@
             android:id="@+id/output_dir"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/bottom_sheet_title_margin_bottom" />
+            android:layout_marginBottom="@dimen/bottom_sheet_title_margin_bottom"
+            android:textAlignment="center" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/select_new_dir"
@@ -62,11 +63,19 @@
             android:text="@string/output_dir_bottom_sheet_file_retention"
             android:textAppearance="?attr/textAppearanceHeadline6" />
 
-        <com.google.android.material.slider.Slider
-            android:id="@+id/retention_slider"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/retention"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:labelBehavior="visible" />
+            android:layout_marginBottom="@dimen/bottom_sheet_title_margin_bottom"
+            android:textAlignment="center" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/edit_retention"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/output_dir_bottom_sheet_edit_retention"
+            style="?attr/materialButtonOutlinedStyle" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/reset"

--- a/app/src/main/res/layout/output_format_bottom_sheet.xml
+++ b/app/src/main/res/layout/output_format_bottom_sheet.xml
@@ -26,7 +26,7 @@
             app:singleSelection="true" />
 
         <LinearLayout
-            android:id="@+id/param_group"
+            android:id="@+id/param_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -39,11 +39,12 @@
                 android:layout_marginBottom="@dimen/bottom_sheet_title_margin_bottom"
                 android:textAppearance="?attr/textAppearanceHeadline6" />
 
-            <com.google.android.material.slider.Slider
-                android:id="@+id/param_slider"
+            <com.chiller3.bcr.ChipGroupCentered
+                android:id="@+id/param_group"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:labelBehavior="visible" />
+                app:selectionRequired="true"
+                app:singleSelection="true" />
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,11 +31,13 @@
     <string name="output_dir_bottom_sheet_filename_template">Filename template</string>
     <string name="output_dir_bottom_sheet_edit_template">Edit template</string>
     <string name="output_dir_bottom_sheet_file_retention">File retention</string>
+    <string name="output_dir_bottom_sheet_edit_retention">Edit retention</string>
     <string name="retention_keep_all">Keep all</string>
     <plurals name="retention_days">
         <item quantity="one">Keep %d day</item>
         <item quantity="other">Keep %d days</item>
     </plurals>
+    <string name="retention_unusable">File retention is disabled because the current filename template is incompatible with the feature.</string>
 
     <!-- Output format bottom sheet -->
     <string name="output_format_bottom_sheet_output_format">Output format</string>
@@ -56,6 +58,11 @@
     <string name="filename_template_dialog_error_invalid_argument">Invalid variable argument: <annotation type="template">PLACEHOLDER</annotation></string>
     <string name="filename_template_dialog_error_invalid_syntax">Template syntax is invalid</string>
     <string name="filename_template_dialog_action_reset_to_default">Reset to default</string>
+
+    <!-- File retention dialog -->
+    <string name="file_retention_dialog_title">@string/output_dir_bottom_sheet_file_retention</string>
+    <string name="file_retention_dialog_message">Enter the number of days to keep recordings.</string>
+    <string name="file_retention_error_too_large">Number is too large</string>
 
     <!-- Format parameter dialog -->
     <string name="format_param_dialog_title">Custom parameter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,10 @@
     <string name="format_param_dialog_title">Custom parameter</string>
     <string name="format_param_dialog_message">Enter a value in the range [%s, %s].</string>
 
+    <!-- Format parameter -->
+    <string name="format_param_bitrate">%s kbps</string>
+    <string name="format_param_compression_level">Level %s</string>
+
     <!-- Dialogs -->
     <string name="dialog_action_ok">OK</string>
     <string name="dialog_action_cancel">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="output_format_bottom_sheet_compression_level">Compression level</string>
     <string name="output_format_bottom_sheet_bitrate">Bitrate</string>
     <string name="output_format_bottom_sheet_sample_rate">Sample rate</string>
+    <string name="output_format_bottom_sheet_custom_param">Custom</string>
 
     <string name="bottom_sheet_reset">Reset to defaults</string>
 
@@ -55,6 +56,10 @@
     <string name="filename_template_dialog_error_invalid_argument">Invalid variable argument: <annotation type="template">PLACEHOLDER</annotation></string>
     <string name="filename_template_dialog_error_invalid_syntax">Template syntax is invalid</string>
     <string name="filename_template_dialog_action_reset_to_default">Reset to default</string>
+
+    <!-- Format parameter dialog -->
+    <string name="format_param_dialog_title">Custom parameter</string>
+    <string name="format_param_dialog_message">Enter a value in the range [%s, %s].</string>
 
     <!-- Dialogs -->
     <string name="dialog_action_ok">OK</string>


### PR DESCRIPTION
Instead of using a slider with a min, max, and step size, the format parameter is configured using chips. For each format, there are three presets and there's an additional option for the user to set a specific compression level or bitrate. The user's existing settings will be preserved.

Fixes: #295