### PR TITLE
Show a separate persistent notification for each call

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -135,8 +135,7 @@ class Notifications(
         @StringRes titleResId: Int,
         message: String?,
         @DrawableRes iconResId: Int,
-        @StringRes actionTextResId: Int,
-        actionIntent: Intent,
+        actions: List<Pair<Int, Intent>>,
     ): Notification {
         val notificationIntent = Intent(context, SettingsActivity::class.java)
         val pendingIntent = PendingIntent.getActivity(
@@ -153,20 +152,22 @@ class Notifications(
             setOngoing(true)
             setOnlyAlertOnce(true)
 
-            val actionPendingIntent = PendingIntent.getService(
-                context,
-                0,
-                actionIntent,
-                PendingIntent.FLAG_IMMUTABLE or
-                        PendingIntent.FLAG_UPDATE_CURRENT or
-                        PendingIntent.FLAG_ONE_SHOT,
-            )
+            for ((actionTextResId, actionIntent) in actions) {
+                val actionPendingIntent = PendingIntent.getService(
+                    context,
+                    0,
+                    actionIntent,
+                    PendingIntent.FLAG_IMMUTABLE or
+                            PendingIntent.FLAG_UPDATE_CURRENT or
+                            PendingIntent.FLAG_ONE_SHOT,
+                )
 
-            addAction(Notification.Action.Builder(
-                null,
-                context.getString(actionTextResId),
-                actionPendingIntent,
-            ).build())
+                addAction(Notification.Action.Builder(
+                    null,
+                    context.getString(actionTextResId),
+                    actionPendingIntent,
+                ).build())
+            }
 
             // Inhibit 10-second delay when showing persistent notification
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -29,8 +29,15 @@ class Notifications(
 
         private val LEGACY_CHANNEL_IDS = arrayOf("alerts")
 
-        /** Incremented for each new alert (non-persistent) notification. */
-        private var notificationId = 2
+        /** Incremented for each new notification. */
+        private var nextNotificationId = 1
+
+        /** Get a new unique notification ID. */
+        fun allocateNotificationId(): Int {
+            val id = nextNotificationId
+            ++nextNotificationId
+            return id
+        }
 
         /** For access to system/internal resource values. */
         private val systemRes = Resources.getSystem()
@@ -125,9 +132,10 @@ class Notifications(
      * notification.
      */
     fun createPersistentNotification(
-        @StringRes title: Int,
-        @DrawableRes icon: Int,
-        @StringRes actionText: Int,
+        @StringRes titleResId: Int,
+        message: String?,
+        @DrawableRes iconResId: Int,
+        @StringRes actionTextResId: Int,
         actionIntent: Intent,
     ): Notification {
         val notificationIntent = Intent(context, SettingsActivity::class.java)
@@ -136,8 +144,11 @@ class Notifications(
         )
 
         return Notification.Builder(context, CHANNEL_ID_PERSISTENT).run {
-            setContentTitle(context.getText(title))
-            setSmallIcon(icon)
+            setContentTitle(context.getText(titleResId))
+            if (message != null) {
+                setContentText(message)
+            }
+            setSmallIcon(iconResId)
             setContentIntent(pendingIntent)
             setOngoing(true)
 
@@ -145,12 +156,14 @@ class Notifications(
                 context,
                 0,
                 actionIntent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                PendingIntent.FLAG_IMMUTABLE or
+                        PendingIntent.FLAG_UPDATE_CURRENT or
+                        PendingIntent.FLAG_ONE_SHOT,
             )
 
             addAction(Notification.Action.Builder(
                 null,
-                context.getString(actionText),
+                context.getString(actionTextResId),
                 actionPendingIntent,
             ).build())
 
@@ -179,6 +192,8 @@ class Notifications(
         errorMsg: String?,
         file: OutputFile?,
     ) {
+        val notificationId = allocateNotificationId()
+
         val notification = Notification.Builder(context, channel).run {
             val text = buildString {
                 val errorMsgTrimmed = errorMsg?.trim()
@@ -262,7 +277,6 @@ class Notifications(
         }
 
         notificationManager.notify(notificationId, notification)
-        ++notificationId
     }
 
     /**
@@ -300,9 +314,11 @@ class Notifications(
 
     /** Dismiss all alert (non-persistent) notifications. */
     fun dismissAll() {
-        // This is safe to run at any time because it doesn't dismiss notifications belonging to
-        // foreground services.
-        notificationManager.cancelAll()
+        for (notification in notificationManager.activeNotifications) {
+            if (!notification.isClearable) {
+                notificationManager.cancel(notification.tag, notification.id)
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -151,6 +151,7 @@ class Notifications(
             setSmallIcon(iconResId)
             setContentIntent(pendingIntent)
             setOngoing(true)
+            setOnlyAlertOnce(true)
 
             val actionPendingIntent = PendingIntent.getService(
                 context,

--- a/app/src/main/java/com/chiller3/bcr/OutputFilenameGenerator.kt
+++ b/app/src/main/java/com/chiller3/bcr/OutputFilenameGenerator.kt
@@ -103,7 +103,7 @@ class OutputFilenameGenerator(
      * @param call Either the parent call or a child of the parent (for conference calls)
      * @param details The updated call details belonging to [call]
      */
-    fun updateCallDetails(call: Call, details: Call.Details) {
+    fun updateCallDetails(call: Call, details: Call.Details): OutputFilename {
         if (call !== parentCall && call.parent !== parentCall) {
             throw IllegalStateException("Not the parent call nor one of its children: $call")
         }
@@ -111,7 +111,7 @@ class OutputFilenameGenerator(
         synchronized(this) {
             callDetails[call] = details
 
-            update(false)
+            return update(false)
         }
     }
 

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -1,6 +1,8 @@
 package com.chiller3.bcr
 
+import android.app.NotificationManager
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -16,23 +18,37 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         private val ACTION_PAUSE = "${RecorderInCallService::class.java.canonicalName}.pause"
         private val ACTION_RESUME = "${RecorderInCallService::class.java.canonicalName}.resume"
         private const val EXTRA_TOKEN = "token"
+        private const val EXTRA_NOTIFICATION_ID = "notification_id"
     }
 
+    private val handler = Handler(Looper.getMainLooper())
+    private lateinit var notificationManager: NotificationManager
     private lateinit var prefs: Preferences
     private lateinit var notifications: Notifications
-    private val handler = Handler(Looper.getMainLooper())
+
+    /**
+     * Notification ID to use for the foreground service. Throughout the lifetime of the service, it
+     * may be associated with different calls. It is not cancelled until all recorders exit.
+     */
+    private val foregroundNotificationId = Notifications.allocateNotificationId()
+
+    /**
+     * Notification IDs and their associated recorders. This indicates the desired state of the
+     * notifications. It may not match the actual state until [updateForegroundState] is called.
+     */
+    private val notificationIdsToRecorders = HashMap<Int, RecorderThread>()
+
+    /**
+     * All notification IDs currently shown. This is used to determine which notifications should be
+     * cancelled after items are removed from [notificationIdsToRecorders].
+     */
+    private val allNotificationIds = HashSet<Int>()
 
     /**
      * Recording threads for each active call. When a call is disconnected, it is immediately
-     * removed from this map and [pendingExit] is incremented.
+     * removed from this map.
      */
-    private val recorders = HashMap<Call, RecorderThread>()
-
-    /**
-     * Number of threads pending exit after the call has been disconnected. This can be negative if
-     * the recording thread fails before the call is disconnected.
-     */
-    private var pendingExit = 0
+    private val callsToRecorders = HashMap<Call, RecorderThread>()
 
     /**
      * Token value for all intents received by this instance of the service.
@@ -71,24 +87,30 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         }
     }
 
-    private fun createBaseIntent(): Intent =
+    private fun createBaseIntent(notificationId: Int): Intent =
         Intent(this, RecorderInCallService::class.java).apply {
+            // The URI is not used for anything besides ensuring that the PendingIntents across
+            // different notifications are unique. PendingIntent treats Intents that differ only in
+            // the extras as the same.
+            data = Uri.fromParts("notification", notificationId.toString(), null)
             putExtra(EXTRA_TOKEN, token)
+            putExtra(EXTRA_NOTIFICATION_ID, notificationId)
         }
 
-    private fun createPauseIntent(): Intent =
-        createBaseIntent().apply {
+    private fun createPauseIntent(notificationId: Int): Intent =
+        createBaseIntent(notificationId).apply {
             action = ACTION_PAUSE
         }
 
-    private fun createResumeIntent(): Intent =
-        createBaseIntent().apply {
+    private fun createResumeIntent(notificationId: Int): Intent =
+        createBaseIntent(notificationId).apply {
             action = ACTION_RESUME
         }
 
     override fun onCreate() {
         super.onCreate()
 
+        notificationManager = getSystemService(NotificationManager::class.java)
         prefs = Preferences(this)
         notifications = Notifications(this)
     }
@@ -101,11 +123,14 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
                 throw IllegalArgumentException("Invalid token")
             }
 
+            val notificationId = intent?.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+            if (notificationId == -1) {
+                throw IllegalArgumentException("Invalid notification ID")
+            }
+
             when (val action = intent?.action) {
                 ACTION_PAUSE, ACTION_RESUME -> {
-                    for ((_, recorder) in recorders) {
-                        recorder.isPaused = action == ACTION_PAUSE
-                    }
+                    notificationIdsToRecorders[notificationId]?.isPaused = action == ACTION_PAUSE
                     updateForegroundState()
                 }
                 else -> throw IllegalArgumentException("Invalid action: $action")
@@ -181,7 +206,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
             requestStopRecording(call)
         }
 
-        recorders[call]?.isHolding = callState == Call.STATE_HOLDING
+        callsToRecorders[call]?.isHolding = callState == Call.STATE_HOLDING
     }
 
     /**
@@ -197,14 +222,21 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
             Log.v(TAG, "Call recording is disabled")
         } else if (!Permissions.haveRequired(this)) {
             Log.v(TAG, "Required permissions have not been granted")
-        } else if (!recorders.containsKey(call)) {
+        } else if (!callsToRecorders.containsKey(call)) {
             val recorder = try {
                 RecorderThread(this, this, call)
             } catch (e: Exception) {
                 notifyFailure(e.message, null)
                 throw e
             }
-            recorders[call] = recorder
+            callsToRecorders[call] = recorder
+
+            val notificationId = if (notificationIdsToRecorders.isEmpty()) {
+                foregroundNotificationId
+            } else {
+                Notifications.allocateNotificationId()
+            }
+            notificationIdsToRecorders[notificationId] = recorder
 
             updateForegroundState()
             recorder.start()
@@ -214,10 +246,10 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     /**
      * Request the cancellation of the [RecorderThread].
      *
-     * The [RecorderThread] is immediately removed from [recorders], but [pendingExit] will be
-     * incremented to keep the foreground notification alive until the [RecorderThread] exits and
-     * reports its status. The thread may exit, decrementing [pendingExit], before this function is
-     * called if an error occurs during recording.
+     * The [RecorderThread] is immediately removed from [callsToRecorders], but will remain in
+     * [notificationIdsToRecorders] to keep the foreground service alive until the [RecorderThread]
+     * exits and reports its status. The thread may exit and be removed from [callsToRecorders]
+     * before this function is called if an error occurs during recording.
      *
      * This function will also unregister [callback] from the call since it's no longer necessary to
      * track further state changes.
@@ -230,14 +262,13 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         // track of which calls have callbacks registered.
         call.unregisterCallback(callback)
 
-        val recorder = recorders[call]
+        val recorder = callsToRecorders[call]
         if (recorder != null) {
             recorder.cancel()
 
-            recorders.remove(call)
+            callsToRecorders.remove(call)
 
             // Don't change the foreground state until the thread has exited
-            ++pendingExit
         }
     }
 
@@ -249,9 +280,9 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     private fun handleDetailsChange(call: Call, details: Call.Details) {
         val parentCall = call.parent
         val recorder = if (parentCall != null) {
-            recorders[parentCall]
+            callsToRecorders[parentCall]
         } else {
-            recorders[call]
+            callsToRecorders[call]
         }
 
         recorder?.onCallDetailsChanged(call, details)
@@ -262,24 +293,61 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
      * recording threads that haven't finished exiting yet.
      */
     private fun updateForegroundState() {
-        if (recorders.isEmpty() && pendingExit == 0) {
+        if (notificationIdsToRecorders.isEmpty()) {
             stopForeground(STOP_FOREGROUND_REMOVE)
         } else {
-            if (recorders.any { it.value.isPaused }) {
-                startForeground(1, notifications.createPersistentNotification(
-                    R.string.notification_recording_paused,
-                    R.drawable.ic_launcher_quick_settings,
-                    R.string.notification_action_resume,
-                    createResumeIntent(),
-                ))
-            } else {
-                startForeground(1, notifications.createPersistentNotification(
-                    R.string.notification_recording_in_progress,
-                    R.drawable.ic_launcher_quick_settings,
-                    R.string.notification_action_pause,
-                    createPauseIntent(),
-                ))
+            // Cancel and remove notifications for recorders that have exited
+            for (notificationId in allNotificationIds.minus(notificationIdsToRecorders.keys)) {
+                // The foreground notification will be overwritten
+                if (notificationId != foregroundNotificationId) {
+                    notificationManager.cancel(notificationId)
+                }
+                allNotificationIds.remove(notificationId)
             }
+
+            // Reassign the foreground notification to another recorder
+            if (foregroundNotificationId !in notificationIdsToRecorders) {
+                val iterator = notificationIdsToRecorders.iterator()
+                val (notificationId, recorder) = iterator.next()
+                iterator.remove()
+                notificationManager.cancel(notificationId)
+                allNotificationIds.remove(notificationId)
+                notificationIdsToRecorders[foregroundNotificationId] = recorder
+            }
+
+            // Create/update notifications
+            for ((notificationId, recorder) in notificationIdsToRecorders) {
+                val (titleResId, actionResId, actionIntent) = if (recorder.isPaused) {
+                    Triple(
+                        R.string.notification_recording_paused,
+                        R.string.notification_action_resume,
+                        createResumeIntent(notificationId),
+                    )
+                } else {
+                    Triple(
+                        R.string.notification_recording_in_progress,
+                        R.string.notification_action_pause,
+                        createPauseIntent(notificationId),
+                    )
+                }
+
+                val notification = notifications.createPersistentNotification(
+                    titleResId,
+                    recorder.filename.value,
+                    R.drawable.ic_launcher_quick_settings,
+                    actionResId,
+                    actionIntent,
+                )
+
+                if (notificationId == foregroundNotificationId) {
+                    startForeground(notificationId, notification)
+                } else {
+                    notificationManager.notify(notificationId, notification)
+                }
+
+                allNotificationIds.add(notificationId)
+            }
+
             notifications.vibrateIfEnabled(Notifications.CHANNEL_ID_PERSISTENT)
         }
     }
@@ -301,15 +369,33 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         )
     }
 
-    private fun onThreadExited() {
-        --pendingExit
+    private fun onRecorderExited(recorder: RecorderThread) {
+        // This may be an early exit if an error occurred while recording. Remove from the map to
+        // make sure the thread doesn't receive any more call-related callbacks.
+        if (callsToRecorders.entries.removeIf { it.value === recorder }) {
+            Log.w(TAG, "$recorder exited before cancellation")
+        }
+
+        // The notification no longer needs to be shown. If this recorder was associated with the
+        // foreground service notification, updateForegroundState() will reassign
+        // foregroundNotificationId to another recorder.
+        assert(notificationIdsToRecorders.entries.removeIf { it.value === recorder }) {
+            "$recorder not found"
+        }
+
         updateForegroundState()
+    }
+
+    override fun onRecordingFilenameChanged(thread: RecorderThread, filename: OutputFilename) {
+        handler.post {
+            updateForegroundState()
+        }
     }
 
     override fun onRecordingCompleted(thread: RecorderThread, file: OutputFile?) {
         Log.i(TAG, "Recording completed: ${thread.id}: ${file?.redacted}")
         handler.post {
-            onThreadExited()
+            onRecorderExited(thread)
 
             // If the recording was initially paused and the user never resumed it, there's no
             // output file, so nothing needs to be shown.
@@ -322,7 +408,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     override fun onRecordingFailed(thread: RecorderThread, errorMsg: String?, file: OutputFile?) {
         Log.w(TAG, "Recording failed: ${thread.id}: ${file?.redacted}")
         handler.post {
-            onThreadExited()
+            onRecorderExited(thread)
 
             notifyFailure(errorMsg, file)
         }

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -65,6 +65,8 @@ class RecorderThread(
     // Filename
     private val outputFilenameGenerator = OutputFilenameGenerator(context, parentCall)
     private val dirUtils = OutputDirUtils(context, outputFilenameGenerator.redactor)
+    val filename: OutputFilename
+        get() = outputFilenameGenerator.filename
 
     // Format
     private val format: Format
@@ -86,7 +88,8 @@ class RecorderThread(
     }
 
     fun onCallDetailsChanged(call: Call, details: Call.Details) {
-        outputFilenameGenerator.updateCallDetails(call, details)
+        val filename = outputFilenameGenerator.updateCallDetails(call, details)
+        listener.onRecordingFilenameChanged(this, filename)
     }
 
     override fun run() {
@@ -455,6 +458,9 @@ class RecorderThread(
     }
 
     interface OnRecordingCompletedListener {
+        /** Called when the output filename is changed. */
+        fun onRecordingFilenameChanged(thread: RecorderThread, filename: OutputFilename)
+
         /**
          * Called when the recording completes successfully. [file] is the output file. If [file] is
          * null, then the recording was started in the paused state and the output file was deleted

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="notification_channel_success_desc">Alerts for successful call recordings</string>
     <string name="notification_recording_in_progress">Call recording in progress</string>
     <string name="notification_recording_paused">Call recording paused</string>
+    <string name="notification_recording_on_hold">Call on hold</string>
     <string name="notification_recording_failed">Failed to record call</string>
     <string name="notification_recording_succeeded">Successfully recorded call</string>
     <string name="notification_internal_android_error">The recording failed in an internal Android component (%s). This device or firmware might not support call recording.</string>


### PR DESCRIPTION
This makes the current state more visible to the user when using call waiting and allows the pause/resume state to be handled correctly. This also adds the filename to the notification text.