### PR TITLE
Add support for auto-record rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ BCR is a simple Android call recording app for rooted devices or devices running
   * FLAC - Lossless, larger files
   * WAV/PCM - Lossless, largest files, least CPU usage
 * Supports Android's Storage Access Framework (can record to SD cards, USB devices, etc.)
+* Per-contact auto-record rules
 * Quick settings toggle
 * Material You dynamic theming
 * No persistent notification unless a recording is in progress
@@ -84,7 +85,7 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
 * `READ_CALL_LOG` (**optional**)
   * If allowed, the name as shown in the call log can be added to the output filename.
 * `READ_CONTACTS` (**optional**)
-  * If allowed, the contact name can be added to the output filename.
+  * If allowed, the contact name can be added to the output filename. It also allows auto-record rules to be set per contact.
 * `READ_PHONE_STATE` (**optional**)
   * If allowed, the SIM slot for devices with multiple active SIMs is added to the output filename.
 * `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (**optional**)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,5 +81,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".rule.RecordRulesActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/chiller3/bcr/ChipGroupCentered.kt
+++ b/app/src/main/java/com/chiller3/bcr/ChipGroupCentered.kt
@@ -10,8 +10,7 @@ import java.lang.Integer.max
 import java.lang.Integer.min
 
 /** Hacky wrapper around [ChipGroup] to make every row individually centered. */
-class ChipGroupCentered(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
-    ChipGroup(context, attrs, defStyleAttr) {
+class ChipGroupCentered : ChipGroup {
     private val _rowCountField = javaClass.superclass.superclass.getDeclaredField("rowCount")
     private var rowCountField
         get() = _rowCountField.getInt(this)
@@ -21,10 +20,15 @@ class ChipGroupCentered(context: Context, attrs: AttributeSet?, defStyleAttr: In
         _rowCountField.isAccessible = true
     }
 
-    constructor(context: Context, attrs: AttributeSet?) :
-        this(context, attrs, com.google.android.material.R.attr.chipGroupStyle)
+    @Suppress("unused")
+    constructor(context: Context) : super(context)
 
-    constructor(context: Context) : this(context, null)
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+            super(context, attrs, defStyleAttr)
 
     @SuppressLint("RestrictedApi")
     override fun onLayout(sizeChanged: Boolean, left: Int, top: Int, right: Int, bottom: Int) {

--- a/app/src/main/java/com/chiller3/bcr/Contact.kt
+++ b/app/src/main/java/com/chiller3/bcr/Contact.kt
@@ -1,0 +1,56 @@
+package com.chiller3.bcr
+
+import android.Manifest
+import android.content.Context
+import android.net.Uri
+import android.provider.ContactsContract
+import androidx.annotation.RequiresPermission
+
+private val PROJECTION = arrayOf(
+    ContactsContract.PhoneLookup.LOOKUP_KEY,
+    ContactsContract.PhoneLookup.DISPLAY_NAME,
+)
+
+data class ContactInfo(
+    val lookupKey: String,
+    val displayName: String,
+)
+
+@RequiresPermission(Manifest.permission.READ_CONTACTS)
+fun findContactsByPhoneNumber(context: Context, number: String): Iterator<ContactInfo> {
+    // Same heuristic as InCallUI's PhoneNumberHelper.isUriNumber()
+    val numberIsSip = number.contains("@") || number.contains("%40")
+
+    val uri = ContactsContract.PhoneLookup.ENTERPRISE_CONTENT_FILTER_URI.buildUpon()
+        .appendPath(number)
+        .appendQueryParameter(
+            ContactsContract.PhoneLookup.QUERY_PARAMETER_SIP_ADDRESS,
+            numberIsSip.toString())
+        .build()
+
+    return findContactsByUri(context, uri)
+}
+
+@RequiresPermission(Manifest.permission.READ_CONTACTS)
+fun findContactByLookupKey(context: Context, lookupKey: String): ContactInfo? {
+    val uri = ContactsContract.Contacts.CONTENT_LOOKUP_URI.buildUpon()
+        .appendPath(lookupKey)
+        .build()
+
+    return findContactsByUri(context, uri).asSequence().firstOrNull()
+}
+
+fun findContactsByUri(context: Context, uri: Uri) = iterator {
+    context.contentResolver.query(uri, PROJECTION, null, null, null)?.use { cursor ->
+        val indexLookupKey = cursor.getColumnIndexOrThrow(ContactsContract.PhoneLookup.LOOKUP_KEY)
+        val indexName = cursor.getColumnIndexOrThrow(ContactsContract.PhoneLookup.DISPLAY_NAME)
+
+        if (cursor.moveToFirst()) {
+            yield(ContactInfo(cursor.getString(indexLookupKey), cursor.getString(indexName)))
+
+            while (cursor.moveToNext()) {
+                yield(ContactInfo(cursor.getString(indexLookupKey), cursor.getString(indexName)))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/LongClickablePreference.kt
+++ b/app/src/main/java/com/chiller3/bcr/LongClickablePreference.kt
@@ -4,22 +4,66 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
+import androidx.preference.SwitchPreferenceCompat
 
 /**
  * A thin shell over [Preference] that allows registering a long click listener.
  */
-class LongClickablePreference(context: Context, attrs: AttributeSet?) : Preference(context, attrs) {
+class LongClickablePreference : Preference {
     var onPreferenceLongClickListener: OnPreferenceLongClickListener? = null
+
+    @Suppress("unused")
+    constructor(context: Context) : super(context)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+            super(context, attrs, defStyleAttr)
 
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
 
-        holder.itemView.setOnLongClickListener {
-            onPreferenceLongClickListener?.onPreferenceLongClick(this) ?: true
+        val listener = onPreferenceLongClickListener
+        if (listener == null) {
+            holder.itemView.setOnLongClickListener(null)
+            holder.itemView.isLongClickable = false
+        } else {
+            holder.itemView.setOnLongClickListener {
+                listener.onPreferenceLongClick(this)
+            }
         }
     }
+}
 
-    interface OnPreferenceLongClickListener {
-        fun onPreferenceLongClick(preference: Preference): Boolean
+class LongClickableSwitchPreference : SwitchPreferenceCompat {
+    var onPreferenceLongClickListener: OnPreferenceLongClickListener? = null
+
+    @Suppress("unused")
+    constructor(context: Context) : super(context)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+            super(context, attrs, defStyleAttr)
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val listener = onPreferenceLongClickListener
+        if (listener == null) {
+            holder.itemView.setOnLongClickListener(null)
+            holder.itemView.isLongClickable = false
+        } else {
+            holder.itemView.setOnLongClickListener {
+                listener.onPreferenceLongClick(this)
+            }
+        }
     }
+}
+
+interface OnPreferenceLongClickListener {
+    fun onPreferenceLongClick(preference: Preference): Boolean
 }

--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -146,6 +146,7 @@ class Notifications(
             setContentTitle(context.getText(titleResId))
             if (message != null) {
                 setContentText(message)
+                style = Notification.BigTextStyle().bigText(message)
             }
             setSmallIcon(iconResId)
             setContentIntent(pendingIntent)

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -26,14 +26,13 @@ object Permissions {
         Manifest.permission.READ_PHONE_STATE,
     )
 
-    fun isGranted(context: Context, permission: String) =
-        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-
     /**
      * Check if all permissions required for call recording have been granted.
      */
     fun haveRequired(context: Context): Boolean =
-        REQUIRED.all { isGranted(context, it) }
+        REQUIRED.all {
+            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        }
 
     /**
      * Check if battery optimizations are currently disabled for this app.
@@ -46,19 +45,17 @@ object Permissions {
     /**
      * Get intent for opening the app info page in the system settings.
      */
-    fun getAppInfoIntent(context: Context): Intent {
-        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-        intent.data = Uri.fromParts("package", context.packageName, null)
-        return intent
-    }
+    fun getAppInfoIntent(context: Context) = Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.fromParts("package", context.packageName, null),
+    )
 
     /**
      * Get intent for requesting the disabling of battery optimization for this app.
      */
     @SuppressLint("BatteryLife")
-    fun getInhibitBatteryOptIntent(context: Context): Intent {
-        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-        intent.data = Uri.fromParts("package", context.packageName, null)
-        return intent
-    }
+    fun getInhibitBatteryOptIntent(context: Context) = Intent(
+        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+        Uri.fromParts("package", context.packageName, null),
+    )
 }

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -9,9 +9,11 @@ class RecorderApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        val props = Preferences(this)
+        props.migrateInitiallyPaused()
         // Migrate the old properties file. This is blocking, but oh well. We can remove the
         // migration logic after a few more releases.
-        Preferences(this).migrateLegacyProperties()
+        props.migrateLegacyProperties()
 
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)

--- a/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/SettingsActivity.kt
@@ -13,6 +13,7 @@ import com.chiller3.bcr.format.Format
 import com.chiller3.bcr.format.NoParamInfo
 import com.chiller3.bcr.format.RangedParamInfo
 import com.chiller3.bcr.format.SampleRate
+import com.chiller3.bcr.rule.RecordRulesActivity
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,10 +32,11 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChangeListener,
-        Preference.OnPreferenceClickListener, LongClickablePreference.OnPreferenceLongClickListener,
+        Preference.OnPreferenceClickListener, OnPreferenceLongClickListener,
         SharedPreferences.OnSharedPreferenceChangeListener {
         private lateinit var prefs: Preferences
         private lateinit var prefCallRecording: SwitchPreferenceCompat
+        private lateinit var prefRecordRules: Preference
         private lateinit var prefOutputDir: Preference
         private lateinit var prefOutputFormat: Preference
         private lateinit var prefInhibitBatteryOpt: SwitchPreferenceCompat
@@ -69,6 +71,9 @@ class SettingsActivity : AppCompatActivity() {
                 prefCallRecording.isChecked = false
             }
             prefCallRecording.onPreferenceChangeListener = this
+
+            prefRecordRules = findPreference(Preferences.PREF_RECORD_RULES)!!
+            prefRecordRules.onPreferenceClickListener = this
 
             prefOutputDir = findPreference(Preferences.PREF_OUTPUT_DIR)!!
             prefOutputDir.onPreferenceClickListener = this
@@ -164,6 +169,10 @@ class SettingsActivity : AppCompatActivity() {
 
         override fun onPreferenceClick(preference: Preference): Boolean {
             when (preference) {
+                prefRecordRules -> {
+                    startActivity(Intent(requireContext(), RecordRulesActivity::class.java))
+                    return true
+                }
                 prefOutputDir -> {
                     OutputDirectoryBottomSheetFragment().show(
                         childFragmentManager, OutputDirectoryBottomSheetFragment.TAG)

--- a/app/src/main/java/com/chiller3/bcr/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/UriExtensions.kt
@@ -2,6 +2,7 @@ package com.chiller3.bcr
 
 import android.content.ContentResolver
 import android.net.Uri
+import android.telecom.PhoneAccount
 
 val Uri.formattedString: String
     get() = when (scheme) {
@@ -26,4 +27,10 @@ val Uri.formattedString: String
             }
         }
         else -> toString()
+    }
+
+val Uri.phoneNumber: String?
+    get() = when (scheme) {
+        PhoneAccount.SCHEME_TEL -> schemeSpecificPart
+        else -> null
     }

--- a/app/src/main/java/com/chiller3/bcr/dialog/MessageDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/dialog/MessageDialogFragment.kt
@@ -1,0 +1,52 @@
+package com.chiller3.bcr.dialog
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.bcr.R
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class MessageDialogFragment : DialogFragment() {
+    companion object {
+        val TAG: String = MessageDialogFragment::class.java.simpleName
+
+        private const val ARG_TITLE = "title"
+        private const val ARG_MESSAGE = "message"
+
+        const val RESULT_SUCCESS = "success"
+
+        fun newInstance(title: CharSequence?, message: CharSequence?) =
+            MessageDialogFragment().apply {
+                arguments = bundleOf(
+                    ARG_TITLE to title,
+                    ARG_MESSAGE to message,
+                )
+            }
+    }
+
+    private var success: Boolean = false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val arguments = requireArguments()
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(arguments.getCharSequence(ARG_TITLE))
+            .setMessage(arguments.getCharSequence(ARG_MESSAGE))
+            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+                success = true
+            }
+            .create()
+            .apply {
+                setCanceledOnTouchOutside(false)
+            }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/extension/CallDetailsExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/CallDetailsExtensions.kt
@@ -1,0 +1,7 @@
+package com.chiller3.bcr.extension
+
+import android.telecom.Call
+import com.chiller3.bcr.phoneNumber
+
+val Call.Details.phoneNumber: String?
+    get() = handle?.phoneNumber

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
@@ -1,0 +1,136 @@
+package com.chiller3.bcr.rule
+
+import android.Manifest
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.util.Log
+import com.chiller3.bcr.findContactsByPhoneNumber
+
+sealed class RecordRule {
+    abstract val record: Boolean
+
+    /**
+     * Check if the rule matches the set of contacts in [contactLookupKeys].
+     *
+     * @param contactLookupKeys The set of contacts, if any, involved in the call. If null, then
+     * [Manifest.permission.READ_CONTACTS] was not granted.
+     */
+    abstract fun matches(contactLookupKeys: Collection<String>?): Boolean
+
+    open fun toRawPreferences(editor: SharedPreferences.Editor, prefix: String) {
+        editor.putString(prefix + PREF_SUFFIX_TYPE, javaClass.simpleName)
+        editor.putBoolean(prefix + PREF_SUFFIX_RECORD, record)
+    }
+
+    class AllCalls(override val record: Boolean) : RecordRule() {
+        override fun matches(contactLookupKeys: Collection<String>?): Boolean = true
+
+        companion object {
+            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): AllCalls {
+                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
+
+                return AllCalls(record)
+            }
+        }
+    }
+
+    class UnknownCalls(override val record: Boolean) : RecordRule() {
+        override fun matches(contactLookupKeys: Collection<String>?): Boolean =
+            contactLookupKeys?.isEmpty() ?: false
+
+        companion object {
+            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): UnknownCalls {
+                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
+
+                return UnknownCalls(record)
+            }
+        }
+    }
+
+    class Contact(val lookupKey: String, override val record: Boolean) : RecordRule() {
+        override fun matches(contactLookupKeys: Collection<String>?): Boolean =
+            contactLookupKeys != null && lookupKey in contactLookupKeys
+
+        override fun toRawPreferences(editor: SharedPreferences.Editor, prefix: String) {
+            super.toRawPreferences(editor, prefix)
+            editor.putString(prefix + PREF_SUFFIX_CONTACT_LOOKUP_KEY, lookupKey)
+        }
+
+        companion object {
+            private const val PREF_SUFFIX_CONTACT_LOOKUP_KEY = "contact_lookup_key"
+
+            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): Contact {
+                val prefLookupKey = prefix + PREF_SUFFIX_CONTACT_LOOKUP_KEY
+                val contactId = prefs.getString(prefLookupKey, null)
+                    ?: throw IllegalArgumentException("Missing $prefLookupKey")
+                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
+
+                return Contact(contactId, record)
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = RecordRule::class.java.simpleName
+
+        private const val PREF_SUFFIX_TYPE = "type"
+        private const val PREF_SUFFIX_RECORD = "record"
+
+        fun fromRawPreferences(prefs: SharedPreferences, prefix: String): RecordRule? {
+            return when (val type = prefs.getString(prefix + PREF_SUFFIX_TYPE, null)) {
+                AllCalls::class.java.simpleName ->
+                    AllCalls.fromRawPreferences(prefs, prefix)
+                UnknownCalls::class.java.simpleName ->
+                    UnknownCalls.fromRawPreferences(prefs, prefix)
+                Contact::class.java.simpleName ->
+                    Contact.fromRawPreferences(prefs, prefix)
+                null -> null
+                else -> {
+                    Log.w(TAG, "Unknown record rule type: $type")
+                    null
+                }
+            }
+        }
+
+        /**
+         * Evaluate list of rules to determine if automatic recording is enabled for any of
+         * [numbers].
+         *
+         * [Contact] and [UnknownCalls] rules are silently ignored if the contacts permission is not
+         * granted.
+         *
+         * @param rules Must contain [AllCalls]
+         *
+         * @throws IllegalArgumentException if [rules] does not contain [AllCalls]
+         */
+        fun evaluate(context: Context, rules: List<RecordRule>,
+                     numbers: Collection<String>): Boolean {
+            val contactsAllowed = context.checkSelfPermission(Manifest.permission.READ_CONTACTS) ==
+                    PackageManager.PERMISSION_GRANTED
+            val contactLookupKeys = if (contactsAllowed) {
+                val keys = hashSetOf<String>()
+
+                for (number in numbers) {
+                    findContactsByPhoneNumber(context, number)
+                        .asSequence()
+                        .map { it.lookupKey }
+                        .toCollection(keys)
+                }
+
+                keys
+            } else {
+                Log.i(TAG, "Contacts permission not granted")
+                null
+            }
+
+            for (rule in rules) {
+                if (rule.matches(contactLookupKeys)) {
+                    return rule.record
+                }
+            }
+
+            throw IllegalArgumentException("Rule list does not contain AllCalls")
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesActivity.kt
@@ -1,0 +1,35 @@
+package com.chiller3.bcr.rule
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import com.chiller3.bcr.R
+
+class RecordRulesActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.settings_activity)
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settings, RecordRulesFragment())
+                .commit()
+        }
+
+        setSupportActionBar(findViewById(R.id.toolbar))
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+
+        setTitle(R.string.pref_record_rules_name)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressedDispatcher.onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
@@ -1,0 +1,215 @@
+package com.chiller3.bcr.rule
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.setFragmentResultListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.get
+import androidx.preference.size
+import com.chiller3.bcr.LongClickableSwitchPreference
+import com.chiller3.bcr.OnPreferenceLongClickListener
+import com.chiller3.bcr.Preferences
+import com.chiller3.bcr.R
+import com.chiller3.bcr.dialog.MessageDialogFragment
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.launch
+import kotlin.properties.Delegates
+
+class RecordRulesFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClickListener,
+    Preference.OnPreferenceChangeListener, OnPreferenceLongClickListener {
+    private val viewModel: RecordRulesViewModel by viewModels()
+
+    private lateinit var prefAddRule: Preference
+
+    private var ruleOffset by Delegates.notNull<Int>()
+    private var rules = emptyList<DisplayedRecordRule>()
+
+    private val requestContact =
+        registerForActivityResult(ActivityResultContracts.PickContact()) { uri ->
+            // We don't bother using persisted URI permissions for the contact because we need the
+            // full READ_CONTACTS permission for this feature to work at all (lookups by number).
+            uri?.let { viewModel.addContactRule(it) }
+        }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.record_rules_preferences, rootKey)
+
+        ruleOffset = preferenceScreen.preferenceCount
+
+        prefAddRule = findPreference(Preferences.PREF_ADD_RULE)!!
+        prefAddRule.onPreferenceClickListener = this
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.messages.collect {
+                    it.firstOrNull()?.let { message ->
+                        when (message) {
+                            Message.ShowHelp -> {
+                                showHelpDialog()
+                                viewModel.acknowledgeFirstMessage()
+                            }
+                            Message.RuleAdded -> {
+                                showSnackBar(getString(R.string.record_rules_rule_added)) {
+                                    viewModel.acknowledgeFirstMessage()
+                                }
+                            }
+                            Message.RuleExists -> {
+                                showSnackBar(getString(R.string.record_rules_rule_exists)) {
+                                    viewModel.acknowledgeFirstMessage()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.rules.collect {
+                    updateRules(it)
+                }
+            }
+        }
+
+        setFragmentResultListener(TAG_HELP) { _, _ ->
+            viewModel.helpDismissed()
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.record_rules, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    R.id.reset -> {
+                        viewModel.reset()
+                        true
+                    }
+                    R.id.help -> {
+                        viewModel.showHelp()
+                        true
+                    }
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+
+    private fun updateRules(newRules: List<DisplayedRecordRule>) {
+        // The list is going to be short enough that it doesn't make sense to use DiffUtil and
+        // deal with PreferenceGroup's awkward indexing/ordering mechanism. Just replace all the
+        // preferences every time.
+
+        val context = requireContext()
+        val contactsGranted = context.checkSelfPermission(Manifest.permission.READ_CONTACTS) ==
+                PackageManager.PERMISSION_GRANTED
+
+        prefAddRule.isEnabled = contactsGranted
+
+        for (i in (ruleOffset until preferenceScreen.size).reversed()) {
+            val p = preferenceScreen[i]
+            preferenceScreen.removePreference(p)
+        }
+
+        for ((i, rule) in newRules.withIndex()) {
+            val p = LongClickableSwitchPreference(context).apply {
+                key = Preferences.PREF_RULE_PREFIX + i
+                isPersistent = false
+                title = when (rule) {
+                    is DisplayedRecordRule.AllCalls ->
+                        getString(R.string.record_rule_type_all_calls)
+                    is DisplayedRecordRule.UnknownCalls ->
+                        getString(R.string.record_rule_type_unknown_calls)
+                    is DisplayedRecordRule.Contact ->
+                        getString(
+                            R.string.record_rule_type_contact,
+                            rule.displayName ?: rule.lookupKey)
+                }
+                summaryOn = getString(R.string.pref_rule_desc_on)
+                summaryOff = getString(R.string.pref_rule_desc_off)
+                isIconSpaceReserved = false
+                isChecked = rule.record
+                isEnabled = rule is DisplayedRecordRule.AllCalls || contactsGranted
+                onPreferenceChangeListener = this@RecordRulesFragment
+                if (rule is DisplayedRecordRule.Contact) {
+                    onPreferenceLongClickListener = this@RecordRulesFragment
+                }
+            }
+            preferenceScreen.addPreference(p)
+        }
+
+        rules = newRules
+    }
+
+    override fun onPreferenceClick(preference: Preference): Boolean {
+        when (preference) {
+            prefAddRule -> {
+                requestContact.launch(null)
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+        when {
+            preference.key.startsWith(Preferences.PREF_RULE_PREFIX) -> {
+                val index = preference.key.substring(Preferences.PREF_RULE_PREFIX.length).toInt()
+                viewModel.setRuleRecord(index, newValue as Boolean)
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun onPreferenceLongClick(preference: Preference): Boolean {
+        when {
+            preference.key.startsWith(Preferences.PREF_RULE_PREFIX) -> {
+                val index = preference.key.substring(Preferences.PREF_RULE_PREFIX.length).toInt()
+                viewModel.deleteRule(index)
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private fun showHelpDialog() {
+        MessageDialogFragment.newInstance(null, getString(R.string.record_rules_help))
+            .show(parentFragmentManager, TAG_HELP)
+    }
+
+    private fun showSnackBar(text: CharSequence, onDismiss: () -> Unit) {
+        Snackbar.make(requireView(), text, Snackbar.LENGTH_LONG)
+            .addCallback(object : Snackbar.Callback() {
+                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                    onDismiss()
+                }
+            })
+            .show()
+    }
+
+    companion object {
+        private val TAG_HELP = "${RecordRulesFragment::class.java}.help"
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesViewModel.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesViewModel.kt
@@ -1,0 +1,242 @@
+package com.chiller3.bcr.rule
+
+import android.Manifest
+import android.app.Application
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.chiller3.bcr.Preferences
+import com.chiller3.bcr.findContactByLookupKey
+import com.chiller3.bcr.findContactsByUri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+sealed class DisplayedRecordRule : Comparable<DisplayedRecordRule> {
+    abstract var record: Boolean
+
+    /**
+     * [Contact] comes first, sorted by display name, followed by [UnknownCalls] and [AllCalls].
+     */
+    override fun compareTo(other: DisplayedRecordRule): Int {
+        when (this) {
+            is AllCalls -> {
+                return when (other) {
+                    is AllCalls -> record.compareTo(other.record)
+                    else -> 1
+                }
+            }
+            is UnknownCalls -> {
+                return when (other) {
+                    is UnknownCalls -> record.compareTo(other.record)
+                    is AllCalls -> -1
+                    is Contact -> 1
+                }
+            }
+            is Contact -> {
+                return when (other) {
+                    is Contact -> compareValuesBy(
+                        this,
+                        other,
+                        { it.displayName },
+                        { it.lookupKey },
+                        { it.record },
+                    )
+                    else -> -1
+                }
+            }
+        }
+    }
+
+    data class AllCalls(override var record: Boolean) : DisplayedRecordRule()
+
+    data class UnknownCalls(override var record: Boolean) : DisplayedRecordRule()
+
+    data class Contact(
+        val lookupKey: String,
+        val displayName: String?,
+        override var record: Boolean,
+    ) : DisplayedRecordRule()
+}
+
+sealed class Message {
+    object ShowHelp : Message()
+
+    object RuleAdded : Message()
+
+    object RuleExists : Message()
+}
+
+class RecordRulesViewModel(application: Application) : AndroidViewModel(application) {
+    private val prefs = Preferences(getApplication())
+
+    private val _messages = MutableStateFlow<List<Message>>(emptyList())
+    val messages: StateFlow<List<Message>> = _messages
+
+    private val _rules = MutableStateFlow<List<DisplayedRecordRule>>(emptyList())
+    val rules: StateFlow<List<DisplayedRecordRule>> = _rules
+
+    init {
+        if (!prefs.recordRulesHelpShown) {
+            showHelp()
+        }
+
+        refreshRules()
+    }
+
+    fun acknowledgeFirstMessage() {
+        _messages.update { it.drop(1) }
+    }
+
+    private fun refreshRules() {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                val rawRules = prefs.recordRules ?: Preferences.DEFAULT_RECORD_RULES
+                val displayRules = rawRules.map { rule ->
+                    when (rule) {
+                        is RecordRule.AllCalls -> DisplayedRecordRule.AllCalls(rule.record)
+                        is RecordRule.UnknownCalls -> DisplayedRecordRule.UnknownCalls(rule.record)
+                        is RecordRule.Contact -> DisplayedRecordRule.Contact(
+                            rule.lookupKey,
+                            getContactDisplayName(rule.lookupKey),
+                            rule.record,
+                        )
+                    }
+                }
+
+                // Update and re-save the rules since the display name may have changed, resulting
+                // in a new sort order.
+                updateAndSaveRules {
+                    displayRules
+                }
+            }
+        }
+    }
+
+    private fun saveRules(newRules: List<DisplayedRecordRule>) {
+        val rawRules = newRules.map { displayedRule ->
+            when (displayedRule) {
+                is DisplayedRecordRule.AllCalls ->
+                    RecordRule.AllCalls(displayedRule.record)
+                is DisplayedRecordRule.UnknownCalls ->
+                    RecordRule.UnknownCalls(displayedRule.record)
+                is DisplayedRecordRule.Contact ->
+                    RecordRule.Contact(displayedRule.lookupKey, displayedRule.record)
+            }
+        }
+
+        if (rawRules == Preferences.DEFAULT_RECORD_RULES) {
+            prefs.recordRules = null
+        } else {
+            prefs.recordRules = rawRules
+        }
+    }
+
+    private fun updateAndSaveRules(
+        block: (old: List<DisplayedRecordRule>) -> List<DisplayedRecordRule>,
+    ) {
+        _rules.update {
+            val newRules = block(it).sorted()
+            saveRules(newRules)
+            newRules
+        }
+    }
+
+    private fun getContactDisplayName(lookupKey: String): String? {
+        if (getApplication<Application>().checkSelfPermission(Manifest.permission.READ_CONTACTS)
+            != PackageManager.PERMISSION_GRANTED) {
+            return null
+        }
+
+        return try {
+            findContactByLookupKey(getApplication(), lookupKey)?.displayName
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to look up contact", e)
+            null
+        }
+    }
+
+    fun addContactRule(uri: Uri) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                val contact = try {
+                    findContactsByUri(getApplication(), uri).asSequence().firstOrNull()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to query contact at $uri", e)
+                    return@withContext
+                }
+                if (contact == null) {
+                    Log.w(TAG, "Contact not found at $uri")
+                    return@withContext
+                }
+
+                val oldRules = rules.value
+                val existingRule = oldRules.find {
+                    it is DisplayedRecordRule.Contact && it.lookupKey == contact.lookupKey
+                }
+
+                if (existingRule != null) {
+                    _messages.update { it + Message.RuleExists }
+                } else {
+                    val newRules = ArrayList(rules.value)
+                    newRules.add(
+                        DisplayedRecordRule.Contact(
+                            contact.lookupKey,
+                            contact.displayName,
+                            true
+                        )
+                    )
+
+                    updateAndSaveRules { newRules }
+
+                    _messages.update { it + Message.RuleAdded }
+                }
+            }
+        }
+    }
+
+    fun setRuleRecord(index: Int, record: Boolean) {
+        updateAndSaveRules {
+            it.mapIndexed { i, displayedRule ->
+                if (i == index) {
+                    when (displayedRule) {
+                        is DisplayedRecordRule.AllCalls -> displayedRule.copy(record = record)
+                        is DisplayedRecordRule.UnknownCalls -> displayedRule.copy(record = record)
+                        is DisplayedRecordRule.Contact -> displayedRule.copy(record = record)
+                    }
+                } else {
+                    displayedRule
+                }
+            }
+        }
+    }
+
+    fun deleteRule(index: Int) {
+        updateAndSaveRules {
+            it.filterIndexed { i, _ -> i != index }
+        }
+    }
+
+    fun showHelp() {
+        _messages.update { it + Message.ShowHelp }
+    }
+
+    fun helpDismissed() {
+        prefs.recordRulesHelpShown = true
+    }
+
+    fun reset() {
+        prefs.recordRules = null
+        prefs.recordRulesHelpShown = false
+        refreshRules()
+    }
+
+    companion object {
+        private val TAG = RecordRulesViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/res/layout/output_directory_bottom_sheet.xml
+++ b/app/src/main/res/layout/output_directory_bottom_sheet.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/app/src/main/res/menu/record_rules.xml
+++ b/app/src/main/res/menu/record_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/reset"
+        android:title="@string/bottom_sheet_reset" />
+    <item android:id="@+id/help"
+        android:title="@string/menu_action_help" />
+</menu>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,10 +9,6 @@
     <string name="pref_call_recording_name">Grabacion de llamada</string>
     <string name="pref_call_recording_desc">Grabar llamadas telefónicas entrantes y salientes. Se requieren permisos de micrófono y notificación para grabar en segundo plano.</string>
 
-    <string name="pref_initially_paused_name">Iniciar pausado</string>
-    <string name="pref_initially_paused_desc_on">La grabación se pausará después de comenzar. Si no lo reanuda con el botón en la notificación, el archivo de salida vacío no se guardará.</string>
-    <string name="pref_initially_paused_desc_off">La llamada se grabará inmediatamente después de conectarse. Para pausar y reanudar, toque el botón en la notificación que se muestra durante una llamada.</string>
-
     <string name="pref_output_dir_name">Directorio de salida</string>
     <string name="pref_output_dir_desc">Elija un directorio para almacenar grabaciones.</string>
 

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -9,10 +9,6 @@
     <string name="pref_call_recording_name">הקלטת שיחה</string>
     <string name="pref_call_recording_desc">הקלט שיחות יוצאות ונכנסות. חובה לאפשר הרשאות למיקרופון ולהתראות, מומלץ לאפשר גישה לטלפון ולאנשי הקשר על מנת שקבצי ההקלטות יישמרו עם נתוני השיחה</string>
 
-    <string name="pref_initially_paused_name">עצור הקלטה</string>
-    <string name="pref_initially_paused_desc_on">ההקלטה לא תפעל בתחילתה. אם לא תפעיל אותה באמצעות הכפתור בהודעה, קובץ ההקלטה הריק לא ישמר</string>
-    <string name="pref_initially_paused_desc_off">השיחה תוקלט מיד בתחילת שיחה. כדי להשהות ולהמשיך, לחץ על הכפתור בהתראה המוצגת במהלך שיחה</string>
-
     <string name="pref_output_dir_name">מיקום האחסון</string>
     <string name="pref_output_dir_desc">בחר תיקיה לאחסון הקלטות</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -9,10 +9,6 @@
     <string name="pref_call_recording_name">Nagrywanie rozmów</string>
     <string name="pref_call_recording_desc">Nagrywaj przychodzące i wychodzące rozmowy telefoniczne. Do nagrywania w tle wymagane są uprawnienia do mikrofonu i powiadomień.</string>
 
-    <string name="pref_initially_paused_name">Domyślnie wstrzymane</string>
-    <string name="pref_initially_paused_desc_on">Nagrywanie zostanie wstrzymane po uruchomieniu. Jeżeli nie wznowisz go przyciskiem w powiadomieniu wyświetlanym w trakcie rozmowy, pusty plik wyjściowy nie zostanie zapisany.</string>
-    <string name="pref_initially_paused_desc_off">Rozmowa będzie nagrywana natychmiast po rozpoczęciu. Możesz wstrzymać i wznowić nagrywanie przyciskiem w powiadomieniu wyświetlanym w trakcie rozmowy.</string>
-
     <string name="pref_output_dir_name">Katalog wyjściowy</string>
     <string name="pref_output_dir_desc">Wybierz katalog do przechowywania nagrań.</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -6,9 +6,6 @@
     <!-- General preferences -->
     <string name="pref_call_recording_name">Запись звонков</string>
     <string name="pref_call_recording_desc">Запись входящих и исходящих телефонных звонков. Для записи в фоновом режиме требуются разрешения на использование микрофона и уведомлений.</string>
-    <string name="pref_initially_paused_name">Остановить запись</string>
-    <string name="pref_initially_paused_desc_on">Запись вызова будет приостановлена после запуска. Если вы не возобновите его с помощью кнопки в шторке уведомлений, отображаемой во время разговора, пустой файл сохранен не будет.</string>
-    <string name="pref_initially_paused_desc_off">Запись вызова начнется автоматически, сразу после подключения. Чтобы сделать паузу и возобновить, нажмите на кнопку в шторке уведомлений, отображаемой во время разговора.</string>
     <string name="pref_output_dir_name">Папка для сохранения</string>
     <string name="pref_output_dir_desc">Выберите папку, в которой будут храниться записи.</string>
     <string name="pref_output_format_name">Выходной формат</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -9,10 +9,6 @@
     <string name="pref_call_recording_name">Nahrávanie hovorov</string>
     <string name="pref_call_recording_desc">Nahráva prichádzajúce a odchádzajúce hovory. Aby nahrávanie fungovalo na pozadí, je potrebné povoliť prístup k mikrofónu a upozorneniam.</string>
 
-    <string name="pref_initially_paused_name">Pôvodne pozastavené</string>
-    <string name="pref_initially_paused_desc_on">Nahrávanie hovorov bude po spojení hovoru pozastavené. Ak nahrávanie nikdy nespustíte, prázdny súbor nebude uložený.</string>
-    <string name="pref_initially_paused_desc_off">Nahrávanie sa automaticky spustí hneď po spojení hovoru. Pozastaviť a pokračovať v nahrávaní môžete klepnutím na tlačidlo v oznamovacej oblasti počas hovoru.</string>
-
     <string name="pref_output_dir_name">Priečinok s nahrávkami</string>
     <string name="pref_output_dir_desc">Vyberte priečinok, kde sa budú ukladať nahrávky.</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -9,10 +9,6 @@
     <string name="pref_call_recording_name">Çağrı kaydı</string>
     <string name="pref_call_recording_desc">Gelen ve giden çağrıları kaydet. Arka planda kayıt için mikrofon ve bildirim izinleri gereklidir.</string>
 
-    <string name="pref_initially_paused_name">Başlangıçta duraklatılmış</string>
-    <string name="pref_initially_paused_desc_on">Kayıt başladıktan sonra duraklatılacaktır. Bildirimdeki düğmeyi kullanarak devam ettirmezseniz, boş çıktı dosyası kaydedilmez.</string>
-    <string name="pref_initially_paused_desc_off">Bağlandıktan hemen sonra çağrı kaydedilecektir. Duraklatmak ve devam ettirmek için, arama sırasında görüntülenen bildirimdeki düğmeye basın</string>
-
     <string name="pref_output_dir_name">Kayıt konumu</string>
     <string name="pref_output_dir_desc">Kayıtlar için bir konum seçin.</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -7,22 +7,18 @@
 
     <!-- General preferences -->
     <string name="pref_call_recording_name">通话录音</string>
-
     <string name="pref_call_recording_desc">对来电和去电进行通话录音，录音时候需要麦克风和通知权限。</string>
-    <string name="pref_initially_paused_name">初始暂停</string>
-    <string name="pref_initially_paused_desc_on">电话接通后不会启用录音功能，需要手动点击通知中心录音按钮才能开启录音。</string>
 
-    <string name="pref_initially_paused_desc_off">电话接通后自动开启录音，如果需要暂停或者恢复录音，需要点击通知中心对应按钮。</string>
     <string name="pref_output_dir_name">保存目录</string>
-
     <string name="pref_output_dir_desc">选择一个目录用来保存录音文件。</string>
-    <string name="pref_output_format_name">保存格式</string>
 
+    <string name="pref_output_format_name">保存格式</string>
     <string name="pref_output_format_desc">选择录音存储编码格式</string>
+
     <string name="pref_inhibit_batt_opt_name">禁用电池优化</string>
+    <string name="pref_inhibit_batt_opt_desc">禁用电池优化可以避免软件在后台被杀死</string>
 
     <!-- About "preference" -->
-    <string name="pref_inhibit_batt_opt_desc">禁用电池优化可以避免软件在后台被杀死</string>
     <string name="pref_version_name">软件版本</string>
 
     <!-- Output directory bottom sheet -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,9 +9,8 @@
     <string name="pref_call_recording_name">Call recording</string>
     <string name="pref_call_recording_desc">Record incoming and outgoing phone calls. Microphone and notification permissions are required for recording in the background.</string>
 
-    <string name="pref_initially_paused_name">Initially paused</string>
-    <string name="pref_initially_paused_desc_on">Recording will be paused after starting. If you don\'t resume it using the button in the notification, the empty output file won\'t be saved.</string>
-    <string name="pref_initially_paused_desc_off">Call will be recorded immediately after connecting. To pause and resume, tap on the button in the notification displayed during a call.</string>
+    <string name="pref_record_rules_name">Auto-record rules</string>
+    <string name="pref_record_rules_desc">Configure which calls should be automatically recorded.</string>
 
     <string name="pref_output_dir_name">Output directory</string>
     <string name="pref_output_dir_desc">Pick a directory to store recordings.</string>
@@ -24,6 +23,18 @@
 
     <!-- About "preference" -->
     <string name="pref_version_name">Version</string>
+
+    <!-- Record rules bottom sheet -->
+    <string name="pref_add_rule_name">Add rule</string>
+    <string name="pref_add_rule_desc">Add an auto-record rule for a contact.</string>
+    <string name="pref_rule_desc_on">Keep the recording.</string>
+    <string name="pref_rule_desc_off">Delete the recording when the call ends.</string>
+    <string name="record_rules_rule_added">Added new rule. Long press the rule to delete it.</string>
+    <string name="record_rules_rule_exists">Rule already exists.</string>
+    <string name="record_rules_help">BCR internally always records every call, but when auto-record is turned off, the recording will be deleted at the end of the call. While a call is in progress, a recording that is scheduled for deletion can be preserved via BCR\'s notification.</string>
+    <string name="record_rule_type_all_calls">All other calls</string>
+    <string name="record_rule_type_unknown_calls">Unknown calls</string>
+    <string name="record_rule_type_contact">Contact: %s</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Change directory</string>
@@ -87,12 +98,17 @@
     <string name="notification_recording_on_hold">Call on hold</string>
     <string name="notification_recording_failed">Failed to record call</string>
     <string name="notification_recording_succeeded">Successfully recorded call</string>
+    <string name="notification_message_delete_at_end">The recording will be deleted at the end of the call. Tap Restore to keep the recording.</string>
     <string name="notification_internal_android_error">The recording failed in an internal Android component (%s). This device or firmware might not support call recording.</string>
     <string name="notification_action_open">Open</string>
     <string name="notification_action_share">Share</string>
     <string name="notification_action_delete">Delete</string>
+    <string name="notification_action_restore">Restore</string>
     <string name="notification_action_pause">Pause</string>
     <string name="notification_action_resume">Resume</string>
+
+    <!-- Menus -->
+    <string name="menu_action_help">Help</string>
 
     <!-- Quick settings tile -->
     <string name="quick_settings_label">Call recording</string>

--- a/app/src/main/res/xml/record_rules_preferences.xml
+++ b/app/src/main/res/xml/record_rules_preferences.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Preference
+        app:key="add_rule"
+        app:persistent="false"
+        app:title="@string/pref_add_rule_name"
+        app:summary="@string/pref_add_rule_desc"
+        app:iconSpaceReserved="false" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -9,11 +9,11 @@
             app:summary="@string/pref_call_recording_desc"
             app:iconSpaceReserved="false" />
 
-        <SwitchPreferenceCompat
-            app:key="initially_paused"
-            app:title="@string/pref_initially_paused_name"
-            app:summaryOff="@string/pref_initially_paused_desc_off"
-            app:summaryOn="@string/pref_initially_paused_desc_on"
+        <Preference
+            app:key="record_rules"
+            app:persistent="false"
+            app:title="@string/pref_record_rules_name"
+            app:summary="@string/pref_record_rules_desc"
             app:iconSpaceReserved="false" />
 
         <Preference


### PR DESCRIPTION
Every call is always recorded initially and the rules determine if the recording should be deleted at the end of the call. The user can override the rules during the middle of a call by using the Delete and Restore buttons in BCR's notification. This allows the user to decide to keep the recording later in the call, even if auto-record was disabled for the caller.

The supported rule types are:

* Specific contact
* Unknown calls
* All other calls

If BCR is not granted the Contacts permission, then only "All other calls" will be available. For simplicity of implementation, there is no way to add rules for specific phone numbers--only contacts. This way Android can do the hard work of performing phone number comparisons.

Rules are processed in order and while the rule matching mechanism can handle an arbitrary rule order, the configuration interface enforces that all the contact rules come first in sorted order, followed by "Unknown calls" and "All other calls". This is again done for simplicity of implementation. This should be sufficient for most use cases, with the caveat that conference calls will follow whichever rule matches first for any of the participants in the call.

This rule mechanism replaces the old "initially paused" setting. Pausing and unpausing no longer has any relation to whether a recording is kept. The old setting will be migrated to the new "Unknown calls" and "All other calls" rules.

Fixes: #320