### PR TITLE
Remove bcr.properties to filename template migration logic

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -5,16 +5,13 @@ import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import androidx.core.content.edit
-import androidx.documentfile.provider.DocumentFile
 import androidx.preference.PreferenceManager
-import com.chiller3.bcr.extension.findFileFast
 import com.chiller3.bcr.format.Format
 import com.chiller3.bcr.format.SampleRate
 import com.chiller3.bcr.output.Retention
 import com.chiller3.bcr.rule.RecordRule
 import com.chiller3.bcr.template.Template
 import java.io.File
-import java.util.Properties
 
 class Preferences(private val context: Context) {
     companion object {
@@ -179,40 +176,6 @@ class Preferences(private val context: Context) {
                 putString(PREF_FILENAME_TEMPLATE, template.toString())
             }
         }
-
-    /**
-     * Migrate legacy properties file based filename template to [Template].
-     *
-     * Will be removed in version 1.45.
-     */
-    fun migrateLegacyProperties() {
-        val outputDir = outputDir?.let {
-            // Only returns null on API <21
-            DocumentFile.fromTreeUri(context, it)!!
-        } ?: DocumentFile.fromFile(defaultOutputDir)
-
-        Log.d(TAG, "Looking for legacy filename template in: ${outputDir.uri}")
-
-        val templateFile = outputDir.findFileFast("bcr.properties")
-        if (templateFile != null) {
-            try {
-                Log.d(TAG, "Migrating legacy filename template: ${templateFile.uri}")
-
-                val props = Properties()
-
-                context.contentResolver.openInputStream(templateFile.uri)?.use {
-                    props.load(it)
-                }
-
-                filenameTemplate = Template.fromLegacyProperties(props)
-                templateFile.renameTo("bcr.properties.migrated")
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to migrate legacy filename template", e)
-            }
-        } else {
-            Log.d(TAG, "No legacy filename template to migrate")
-        }
-    }
 
     /**
      * The saved file retention (in days).

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -12,9 +12,6 @@ class RecorderApplication : Application() {
 
         val props = Preferences(this)
         props.migrateInitiallyPaused()
-        // Migrate the old properties file. This is blocking, but oh well. We can remove the
-        // migration logic after a few more releases.
-        props.migrateLegacyProperties()
 
         // Enable Material You colors
         DynamicColors.applyToActivitiesIfAvailable(this)

--- a/app/src/main/java/com/chiller3/bcr/template/Template.kt
+++ b/app/src/main/java/com/chiller3/bcr/template/Template.kt
@@ -17,7 +17,6 @@ import com.copperleaf.kudzu.parser.mapped.MappedParser
 import com.copperleaf.kudzu.parser.maybe.MaybeParser
 import com.copperleaf.kudzu.parser.sequence.SequenceParser
 import com.copperleaf.kudzu.parser.text.IdentifierTokenParser
-import java.util.*
 
 class Template(template: String) {
     companion object {
@@ -177,63 +176,6 @@ class Template(template: String) {
             ),
         ) {
             it.node1.value
-        }
-
-        /**
-         * Convert the legacy properties file template format to a string template.
-         */
-        fun fromLegacyProperties(props: Properties): Template {
-            val clean = { value: String ->
-                // Android's regex implementation requires the "redundant" escapes
-                @Suppress("RegExpRedundantEscape")
-                value
-                    .replace("\\\$\\{([^\\}]+)\\}".toRegex(), "\u0000$1\u0000")
-                    .let { escape(it) }
-                    .replace("\u0000([^\u0000]+)\u0000".toRegex(), "{$1}")
-            }
-
-            var index = 0
-            val template = StringBuilder()
-
-            while (true) {
-                val textRaw = props.getProperty("filename.$index.text") ?: break
-                val defaultRaw = props.getProperty("filename.$index.default")
-                val prefixRaw = props.getProperty("filename.$index.prefix")
-                val suffixRaw = props.getProperty("filename.$index.suffix")
-                val text = clean(textRaw)
-                val default = defaultRaw?.let { clean(it) }
-                val prefix = prefixRaw?.let { clean(it) }
-                val suffix = suffixRaw?.let { clean(it) }
-
-                if (default == null && prefix == null && suffix == null) {
-                    template.append(text)
-                } else {
-                    template.append('[')
-                    if (prefix != null) {
-                        template.append(prefix)
-                    }
-                    if (default != null) {
-                        template.append('[')
-                        template.append(text)
-                        template.append('|')
-                        template.append(default)
-                        template.append(']')
-                    } else {
-                        template.append(text)
-                    }
-                    if (suffix != null) {
-                        template.append(suffix)
-                    }
-                    if (default == null || default.contains('$')) {
-                        template.append('|')
-                    }
-                    template.append(']')
-                }
-
-                ++index
-            }
-
-            return Template(template.toString())
         }
 
         /**

--- a/app/src/test/java/com/chiller3/bcr/template/TemplateTest.kt
+++ b/app/src/test/java/com/chiller3/bcr/template/TemplateTest.kt
@@ -199,24 +199,6 @@ class TemplateTest {
     }
 
     @Test
-    fun testLegacyPropertiesToTemplate() {
-        val props = Properties()
-        props["filename.0.text"] = "\${var:arg}"
-        props["filename.1.text"] = "\${missing}"
-        props["filename.1.default"] = "|"
-        props["filename.1.prefix"] = "{"
-        props["filename.1.suffix"] = "}"
-        props["filename.2.text"] = "\${missing}"
-        props["filename.2.prefix"] = "["
-        props["filename.2.suffix"] = "]"
-
-        assertEquals(
-            "{var:arg}[\\{[{missing}|\\|]\\}][\\[{missing}\\]|]",
-            Template.fromLegacyProperties(props).toString(),
-        )
-    }
-
-    @Test
     fun testEvaluate() {
         fun getVar(name: String, arg: String?): String? {
             return when (name) {


### PR DESCRIPTION
This was planned for removal in version 1.45.