### PR TITLE
Add support for directory separators in the filename template

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -24,7 +24,8 @@ class RecorderApplication : Application() {
             try {
                 val redactor = OutputDirUtils.NULL_REDACTOR
                 val dirUtils = OutputDirUtils(this, redactor)
-                val logcatFile = dirUtils.createFileInDefaultDir("crash.log", "text/plain")
+                val logcatPath = listOf("crash.log")
+                val logcatFile = dirUtils.createFileInDefaultDir(logcatPath, "text/plain")
 
                 Log.e(TAG, "Saving logcat to ${redactor.redact(logcatFile.uri)} due to uncaught exception in $t", e)
 
@@ -35,7 +36,7 @@ class RecorderApplication : Application() {
                         .start()
                         .waitFor()
                 } finally {
-                    dirUtils.tryMoveToUserDir(logcatFile)
+                    dirUtils.tryMoveToOutputDir(logcatFile, logcatPath)
                 }
             } finally {
                 oldCrashHandler?.uncaughtException(t, e)

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -343,7 +343,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
                     actionIntents.add(createActionIntent(notificationId, ACTION_PAUSE))
                 }
 
-                val message = StringBuilder(recorder.filename.value)
+                val message = StringBuilder(recorder.path.unredacted)
 
                 recorder.keepRecording?.let {
                     if (it) {

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -329,31 +329,47 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
                 val titleResId: Int
                 val actionResIds = mutableListOf<Int>()
                 val actionIntents = mutableListOf<Intent>()
+                val canShowDelete: Boolean
 
-                if (recorder.isHolding) {
-                    titleResId = R.string.notification_recording_on_hold
-                    // Don't allow changing the pause state while holding
-                } else if (recorder.isPaused) {
-                    titleResId = R.string.notification_recording_paused
-                    actionResIds.add(R.string.notification_action_resume)
-                    actionIntents.add(createActionIntent(notificationId, ACTION_RESUME))
-                } else {
-                    titleResId = R.string.notification_recording_in_progress
-                    actionResIds.add(R.string.notification_action_pause)
-                    actionIntents.add(createActionIntent(notificationId, ACTION_PAUSE))
+                when (recorder.state) {
+                    RecorderThread.State.NOT_STARTED -> {
+                        titleResId = R.string.notification_recording_initializing
+                        canShowDelete = true
+                    }
+                    RecorderThread.State.RECORDING -> {
+                        if (recorder.isHolding) {
+                            titleResId = R.string.notification_recording_on_hold
+                            // Don't allow changing the pause state while holding
+                        } else if (recorder.isPaused) {
+                            titleResId = R.string.notification_recording_paused
+                            actionResIds.add(R.string.notification_action_resume)
+                            actionIntents.add(createActionIntent(notificationId, ACTION_RESUME))
+                        } else {
+                            titleResId = R.string.notification_recording_in_progress
+                            actionResIds.add(R.string.notification_action_pause)
+                            actionIntents.add(createActionIntent(notificationId, ACTION_PAUSE))
+                        }
+                        canShowDelete = true
+                    }
+                    RecorderThread.State.FINALIZING, RecorderThread.State.COMPLETED -> {
+                        titleResId = R.string.notification_recording_finalizing
+                        canShowDelete = false
+                    }
                 }
 
                 val message = StringBuilder(recorder.path.unredacted)
 
-                recorder.keepRecording?.let {
-                    if (it) {
-                        actionResIds.add(R.string.notification_action_delete)
-                        actionIntents.add(createActionIntent(notificationId, ACTION_DELETE))
-                    } else {
-                        message.append("\n\n")
-                        message.append(getString(R.string.notification_message_delete_at_end))
-                        actionResIds.add(R.string.notification_action_restore)
-                        actionIntents.add(createActionIntent(notificationId, ACTION_RESTORE))
+                if (canShowDelete) {
+                    recorder.keepRecording?.let {
+                        if (it) {
+                            actionResIds.add(R.string.notification_action_delete)
+                            actionIntents.add(createActionIntent(notificationId, ACTION_DELETE))
+                        } else {
+                            message.append("\n\n")
+                            message.append(getString(R.string.notification_message_delete_at_end))
+                            actionResIds.add(R.string.notification_action_restore)
+                            actionIntents.add(createActionIntent(notificationId, ACTION_RESTORE))
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -12,10 +12,10 @@ import android.telecom.Call
 import android.util.Log
 import androidx.core.net.toFile
 import androidx.documentfile.provider.DocumentFile
+import com.chiller3.bcr.extension.deleteIfEmptyDir
 import com.chiller3.bcr.extension.frameSizeInBytesCompat
-import com.chiller3.bcr.extension.listFilesWithNames
+import com.chiller3.bcr.extension.listFilesWithPathsRecursively
 import com.chiller3.bcr.extension.phoneNumber
-import com.chiller3.bcr.extension.renameToPreserveExt
 import com.chiller3.bcr.format.Encoder
 import com.chiller3.bcr.format.Format
 import com.chiller3.bcr.format.SampleRate
@@ -23,8 +23,8 @@ import com.chiller3.bcr.output.DaysRetention
 import com.chiller3.bcr.output.NoRetention
 import com.chiller3.bcr.output.OutputDirUtils
 import com.chiller3.bcr.output.OutputFile
-import com.chiller3.bcr.output.OutputFilename
 import com.chiller3.bcr.output.OutputFilenameGenerator
+import com.chiller3.bcr.output.OutputPath
 import com.chiller3.bcr.output.Retention
 import com.chiller3.bcr.rule.RecordRule
 import java.lang.Process
@@ -106,8 +106,8 @@ class RecorderThread(
     // Filename
     private val outputFilenameGenerator = OutputFilenameGenerator(context, parentCall)
     private val dirUtils = OutputDirUtils(context, outputFilenameGenerator.redactor)
-    val filename: OutputFilename
-        get() = outputFilenameGenerator.filename
+    val path: OutputPath
+        get() = outputFilenameGenerator.path
 
     // Format
     private val format: Format
@@ -115,7 +115,7 @@ class RecorderThread(
     private val sampleRate = SampleRate.fromPreferences(prefs)
 
     // Logging
-    private lateinit var logcatFilename: OutputFilename
+    private lateinit var logcatPath: OutputPath
     private lateinit var logcatFile: DocumentFile
     private lateinit var logcatProcess: Process
 
@@ -176,9 +176,9 @@ class RecorderThread(
             } else {
                 evaluateRules()
 
-                val initialFilename = outputFilenameGenerator.filename
+                val initialPath = outputFilenameGenerator.path
                 val outputFile = dirUtils.createFileInDefaultDir(
-                    initialFilename.value, format.mimeTypeContainer)
+                    initialPath.value, format.mimeTypeContainer)
                 resultUri = outputFile.uri
 
                 try {
@@ -187,23 +187,14 @@ class RecorderThread(
                         Os.fsync(it.fileDescriptor)
                     }
                 } finally {
-                    val finalFilename = outputFilenameGenerator.update(true)
-                    if (finalFilename != initialFilename) {
-                        Log.i(tag, "Renaming $initialFilename to $finalFilename")
-
-                        if (outputFile.renameToPreserveExt(finalFilename.value)) {
-                            resultUri = outputFile.uri
-                        } else {
-                            Log.w(tag, "Failed to rename to final filename: $finalFilename")
-                        }
-                    }
+                    val finalPath = outputFilenameGenerator.update(true)
 
                     if (keepRecording != false) {
-                        dirUtils.tryMoveToUserDir(outputFile)?.let {
+                        dirUtils.tryMoveToOutputDir(outputFile, finalPath.value)?.let {
                             resultUri = it.uri
                         }
                     } else {
-                        Log.i(tag, "Deleting recording: $finalFilename")
+                        Log.i(tag, "Deleting recording: $finalPath")
                         outputFile.delete()
                         resultUri = null
                     }
@@ -265,9 +256,13 @@ class RecorderThread(
         isCancelled = true
     }
 
-    private fun getLogcatFilename(): OutputFilename {
-        return outputFilenameGenerator.filename.let {
-            it.copy(value = it.value + ".log", redacted = it.redacted + ".log")
+    private fun getLogcatPath(): OutputPath {
+        return outputFilenameGenerator.path.let {
+            val path = it.value.mapIndexed { i, p ->
+                p + if (i == it.value.size - 1) { ".log" } else { "" }
+            }
+
+            it.copy(value = path, redacted = it.redacted + ".log")
         }
     }
 
@@ -280,8 +275,8 @@ class RecorderThread(
 
         Log.d(tag, "Starting log file (${BuildConfig.VERSION_NAME})")
 
-        logcatFilename = getLogcatFilename()
-        logcatFile = dirUtils.createFileInDefaultDir(logcatFilename.value, "text/plain")
+        logcatPath = getLogcatPath()
+        logcatFile = dirUtils.createFileInDefaultDir(logcatPath.value, "text/plain")
         logcatProcess = ProcessBuilder("logcat", "*:V")
             // This is better than -f because the logcat implementation calls fflush() when the
             // output stream is stdout. logcatFile is guaranteed to have file:// scheme because it's
@@ -311,16 +306,8 @@ class RecorderThread(
                 logcatProcess.waitFor()
             }
         } finally {
-            val finalLogcatFilename = getLogcatFilename()
-            if (finalLogcatFilename != logcatFilename) {
-                Log.i(tag, "Renaming $logcatFilename to $finalLogcatFilename")
-
-                if (!logcatFile.renameToPreserveExt(finalLogcatFilename.value)) {
-                    Log.w(tag, "Failed to rename to final filename: $finalLogcatFilename")
-                }
-            }
-
-            dirUtils.tryMoveToUserDir(logcatFile)
+            val finalLogcatPath = getLogcatPath()
+            dirUtils.tryMoveToOutputDir(logcatFile, finalLogcatPath.value)
         }
     }
 
@@ -346,15 +333,19 @@ class RecorderThread(
         }
         Log.i(tag, "Retention period is $retention")
 
-        for ((item, name) in directory.listFilesWithNames()) {
-            if (name == null) {
+        val potentiallyEmptyDirs = mutableListOf<Pair<DocumentFile, List<String>>>()
+
+        for ((item, itemPath) in directory.listFilesWithPathsRecursively()) {
+            if (item.isDirectory) {
+                potentiallyEmptyDirs.add(Pair(item, itemPath))
                 continue
             }
-            val redacted = OutputFilenameGenerator.redactTruncate(name)
 
-            val timestamp = outputFilenameGenerator.parseTimestampFromFilename(name)
+            val redacted = OutputFilenameGenerator.redactTruncate(itemPath.joinToString("/"))
+
+            val timestamp = outputFilenameGenerator.parseTimestampFromPath(itemPath)
             if (timestamp == null) {
-                Log.w(tag, "Ignoring unrecognized filename: $redacted")
+                Log.w(tag, "Ignoring unrecognized path: $redacted")
                 continue
             }
 
@@ -365,6 +356,13 @@ class RecorderThread(
                 if (!item.delete()) {
                     Log.w(tag, "Failed to delete: $redacted")
                 }
+            }
+        }
+
+        for ((dir, dirPath) in potentiallyEmptyDirs.asReversed()) {
+            if (dir.deleteIfEmptyDir()) {
+                val redacted = OutputFilenameGenerator.redactTruncate(dirPath.joinToString("/"))
+                Log.i(tag, "Deleted empty directory: $redacted")
             }
         }
     }

--- a/app/src/main/java/com/chiller3/bcr/extension/DocumentFileExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/DocumentFileExtensions.kt
@@ -5,24 +5,33 @@ import android.content.Context
 import android.net.Uri
 import android.provider.DocumentsContract
 import android.util.Log
+import androidx.core.net.toFile
 import androidx.documentfile.provider.DocumentFile
+import java.io.File
 
 private const val TAG = "DocumentFileExtensions"
 
-private fun DocumentFile.iterChildrenWithColumns(extraColumns: Array<String>) = iterator {
-    if (!DocumentsContract.isTreeUri(uri)) {
-        throw IllegalArgumentException("Not a tree URI")
+/** Get the internal [Context] for a DocumentsProvider-backed file. */
+private val DocumentFile.context: Context?
+    get() = when (uri.scheme) {
+        ContentResolver.SCHEME_CONTENT -> {
+            javaClass.getDeclaredField("mContext").apply {
+                isAccessible = true
+            }.get(this) as Context
+        }
+        else -> null
     }
+
+private val DocumentFile.isTree: Boolean
+    get() = uri.scheme == ContentResolver.SCHEME_CONTENT && DocumentsContract.isTreeUri(uri)
+
+private fun DocumentFile.iterChildrenWithColumns(extraColumns: Array<String>) = iterator {
+    require(isTree) { "Not a tree URI" }
 
     val file = this@iterChildrenWithColumns
 
     // These reflection calls access private fields, but everything is part of the
     // androidx.documentfile:documentfile dependency and we control the version of that.
-
-    val context = file.javaClass.getDeclaredField("mContext").apply {
-        isAccessible = true
-    }.get(file) as Context
-
     val constructor = file.javaClass.getDeclaredConstructor(
         DocumentFile::class.java,
         Context::class.java,
@@ -31,7 +40,7 @@ private fun DocumentFile.iterChildrenWithColumns(extraColumns: Array<String>) = 
         isAccessible = true
     }
 
-    context.contentResolver.query(
+    context!!.contentResolver.query(
         DocumentsContract.buildChildDocumentsUriUsingTree(
             uri,
             DocumentsContract.getDocumentId(uri),
@@ -58,9 +67,9 @@ private fun DocumentFile.iterChildrenWithColumns(extraColumns: Array<String>) = 
  * [DocumentFile.getName] for each entry. For tree URIs, this only performs a single query to the
  * document provider.
  */
-fun DocumentFile.listFilesWithNames(): List<Pair<DocumentFile, String?>> {
-    if (!DocumentsContract.isTreeUri(uri)) {
-        return listFiles().map { Pair(it, it.name) }
+fun DocumentFile.listFilesWithNames(): List<Pair<DocumentFile, String>> {
+    if (!isTree) {
+        return listFiles().map { Pair(it, it.name!!) }
     }
 
     try {
@@ -76,6 +85,30 @@ fun DocumentFile.listFilesWithNames(): List<Pair<DocumentFile, String?>> {
 }
 
 /**
+ * Recursively list files along with their paths.
+ *
+ * Uses [listFilesWithNames] for faster iteration with tree URIs.
+ */
+fun DocumentFile.listFilesWithPathsRecursively(): List<Pair<DocumentFile, List<String>>> {
+    val result = mutableListOf<Pair<DocumentFile, List<String>>>()
+
+    fun recurse(dir: DocumentFile, path: List<String>) {
+        for ((file, name) in dir.listFilesWithNames()) {
+            val subPath = path + name
+
+            result.add(Pair(file, subPath))
+
+            if (file.isDirectory) {
+                recurse(file, subPath)
+            }
+        }
+    }
+
+    recurse(this, emptyList())
+    return result
+}
+
+/**
  * Like [DocumentFile.findFile], but faster for tree URIs.
  *
  * [DocumentFile.findFile] performs a query for the document ID list and then performs separate
@@ -84,7 +117,7 @@ fun DocumentFile.listFilesWithNames(): List<Pair<DocumentFile, String?>> {
  * [DocumentsContract.Document.COLUMN_DISPLAY_NAME] can be queried at the same time.
  */
 fun DocumentFile.findFileFast(displayName: String): DocumentFile? {
-    if (!DocumentsContract.isTreeUri(uri)) {
+    if (!isTree) {
         return findFile(displayName)
     }
 
@@ -98,6 +131,44 @@ fun DocumentFile.findFileFast(displayName: String): DocumentFile? {
     }
 
     return null
+}
+
+/** Like [DocumentFile.findFileFast], but accepts nested paths. */
+fun DocumentFile.findNestedFile(path: List<String>): DocumentFile? {
+    var file = this
+    for (segment in path) {
+        file = file.findFileFast(segment) ?: return null
+    }
+    return file
+}
+
+/**
+ * Find the subdirectory [path] or create it if it doesn't already exist, including any intermediate
+ * subdirectories.
+ */
+fun DocumentFile.findOrCreateDirectories(path: List<String>): DocumentFile? {
+    var file = this
+    for (segment in path) {
+        file = file.findFileFast(segment)
+            ?: file.createDirectory(segment)
+            ?: return null
+    }
+    return file
+}
+
+/**
+ * Like [DocumentFile.createFile], but accepts a nested path and automatically creates intermediate
+ * subdirectories.
+ *
+ * @param path Path to the file, which must be non-empty. The last element specifies the filename
+ * and should not include a file extension.
+ * @param mimeType MIME type of the file, which determines the file extension.
+ */
+fun DocumentFile.createNestedFile(mimeType: String, path: List<String>): DocumentFile? {
+    require(path.isNotEmpty()) { "Path cannot be empty" }
+
+    return findOrCreateDirectories(path.dropLast(1))
+        ?.createFile(mimeType, path.last())
 }
 
 /**
@@ -126,4 +197,124 @@ fun DocumentFile.renameToPreserveExt(displayName: String): Boolean {
     }
 
     return renameTo(newName)
+}
+
+/** Get the flags for a DocumentsProvider-backed file. */
+private val DocumentFile.flags: Int
+    get() {
+        require(uri.scheme == ContentResolver.SCHEME_CONTENT) {
+            throw IllegalArgumentException("Not a DocumentsProvider URI")
+        }
+
+        context!!.contentResolver.query(
+            uri,
+            arrayOf(DocumentsContract.Document.COLUMN_FLAGS),
+            null, null, null,
+        )?.use {
+            if (it.moveToFirst()) {
+                return it.getInt(0)
+            }
+        }
+
+        return 0
+    }
+
+class NotEfficientlyMovableException(msg: String, cause: Throwable? = null)
+    : IllegalArgumentException(msg, cause)
+
+/**
+ * Try to efficiently move the file to the [targetParent] directory.
+ *
+ * A file can be efficiently (without copy + delete) moved if:
+ * * the source and destination are the same type (file:// or DocumentsProvider authority)
+ * * the source and destination must be on the same mount point (for file://)
+ * * the source file has a known parent (via [DocumentFile.getParentFile])
+ * * the source file advertises [DocumentsContract.Document.FLAG_SUPPORTS_MOVE]
+ *
+ * After moving, the filename remains the same. What happens when [targetParent] already has a file
+ * with the same name is unspecified because the [DocumentsContract] API provides no guarantees with
+ * regards to this scenario.
+ */
+fun DocumentFile.moveToDirectory(targetParent: DocumentFile): DocumentFile? {
+    if (uri.scheme != targetParent.uri.scheme) {
+        throw NotEfficientlyMovableException("Source scheme (${uri.scheme}) != " +
+                "target parent scheme (${targetParent.uri.scheme})")
+    }
+
+    when (uri.scheme) {
+        ContentResolver.SCHEME_FILE -> {
+            val sourceFile = uri.toFile()
+            val targetFile = File(targetParent.uri.toFile(), sourceFile.name)
+
+            return if (sourceFile.absolutePath == targetFile.absolutePath) {
+                this
+            } else if (sourceFile.renameTo(targetFile)) {
+                DocumentFile.fromFile(targetFile)
+            } else {
+                null
+            }
+        }
+        ContentResolver.SCHEME_CONTENT -> {
+            if (uri.authority != targetParent.uri.authority) {
+                throw NotEfficientlyMovableException("Source authority (${uri.authority}) != " +
+                        "target parent authority (${targetParent.uri.authority})")
+            } else if (flags and DocumentsContract.Document.FLAG_SUPPORTS_MOVE == 0) {
+                throw NotEfficientlyMovableException("File does not advertise move flag")
+            } else if (parentFile == null) {
+                throw NotEfficientlyMovableException("File does not have known parent")
+            }
+
+            if (parentFile!!.uri == targetParent.uri) {
+                return this
+            }
+
+            return try {
+                val targetUri = DocumentsContract.moveDocument(
+                    context!!.contentResolver,
+                    uri,
+                    parentFile!!.uri,
+                    targetParent.uri,
+                )
+
+                targetUri?.let { DocumentFile.fromTreeUri(context!!, targetUri) }
+            } catch (e: Exception) {
+                null
+            }
+        }
+        else -> throw IllegalArgumentException("Unsupported scheme: ${uri.scheme}")
+    }
+}
+
+private fun DocumentFile.isEmpty(): Boolean {
+    require(isDirectory) { "Not a directory" }
+
+    return if (isTree) {
+        !iterChildrenWithColumns(emptyArray()).hasNext()
+    } else {
+        listFiles().isEmpty()
+    }
+}
+
+/**
+ * Delete this document if it refers to an empty directory.
+ *
+ * This is subject to TOCTTOU issues because SAF does not have a non-recursive delete function.
+ */
+fun DocumentFile.deleteIfEmptyDir(): Boolean {
+    if (isDirectory && isEmpty()) {
+        return delete()
+    }
+
+    return false
+}
+
+fun DocumentFile.deleteIfEmptyDirRecursively() {
+    var current: DocumentFile? = this
+
+    while (current != null) {
+        if (!current.deleteIfEmptyDir()) {
+            return
+        }
+        current = current.parentFile
+    }
 }

--- a/app/src/main/java/com/chiller3/bcr/extension/DocumentFileExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/DocumentFileExtensions.kt
@@ -171,29 +171,20 @@ fun DocumentFile.createNestedFile(mimeType: String, path: List<String>): Documen
         ?.createFile(mimeType, path.last())
 }
 
-/**
- * Like [DocumentFile.renameTo], but preserves the extension for file URIs.
- *
- * This fixes [DocumentFile.renameTo]'s behavior so it is the same for both SAF and file URIs.
- */
+/** Like [DocumentFile.renameTo], but preserves the file extension. */
 fun DocumentFile.renameToPreserveExt(displayName: String): Boolean {
-    val newName = when (uri.scheme) {
-        ContentResolver.SCHEME_FILE -> {
-            buildString {
-                append(displayName)
+    val newName = buildString {
+        append(displayName)
 
-                // This intentionally just does simple string operations because MimeTypeMap's
-                // getExtensionFromMimeType() and getMimeTypeFromExtension() are not consistent with
-                // each other. Eg. audio/mp4 -> m4a -> audio/mpeg -> mp3.
+        // This intentionally just does simple string operations because MimeTypeMap's
+        // getExtensionFromMimeType() and getMimeTypeFromExtension() are not consistent with
+        // each other. Eg. audio/mp4 -> m4a -> audio/mpeg -> mp3.
 
-                val ext = name!!.substringAfterLast('.', "")
-                if (ext.isNotEmpty()) {
-                    append('.')
-                    append(ext)
-                }
-            }
+        val ext = name!!.substringAfterLast('.', "")
+        if (ext.isNotEmpty()) {
+            append('.')
+            append(ext)
         }
-        else -> displayName
     }
 
     return renameTo(newName)

--- a/app/src/main/java/com/chiller3/bcr/output/OutputDirUtils.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputDirUtils.kt
@@ -9,46 +9,62 @@ import android.system.OsConstants
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import com.chiller3.bcr.Preferences
+import com.chiller3.bcr.extension.NotEfficientlyMovableException
+import com.chiller3.bcr.extension.createNestedFile
+import com.chiller3.bcr.extension.deleteIfEmptyDirRecursively
+import com.chiller3.bcr.extension.findNestedFile
+import com.chiller3.bcr.extension.findOrCreateDirectories
+import com.chiller3.bcr.extension.moveToDirectory
+import com.chiller3.bcr.extension.renameToPreserveExt
+import java.io.FileNotFoundException
 import java.io.IOException
 
 class OutputDirUtils(private val context: Context, private val redactor: Redactor) {
     private val prefs = Preferences(context)
 
-    /**
-     * Try to move [sourceFile] to the user output directory.
-     *
-     * @return Whether the user output directory is set and the file was successfully moved
-     */
-    fun tryMoveToUserDir(sourceFile: DocumentFile): DocumentFile? {
-        val userDir = prefs.outputDir?.let {
-            // Only returns null on API <21
-            DocumentFile.fromTreeUri(context, it)!!
-        } ?: return null
+    private fun getErrorFallbackPath(path: List<String>) =
+        listOf("ERROR_${path.joinToString("_")}")
 
-        val redactedSource = redactor.redact(sourceFile.uri)
+    private fun getExistingPath(root: DocumentFile, path: List<String>): DocumentFile {
+        return root.findNestedFile(path)
+            ?: throw FileNotFoundException("Failed to find " + redactor.redact(path) + " in " +
+                    redactor.redact(root.uri))
+    }
 
-        return try {
-            val targetFile = moveFileToDir(sourceFile, userDir)
-            val redactedTarget = redactor.redact(targetFile.uri)
+    private fun getOrCreateDirectory(root: DocumentFile, path: List<String>): DocumentFile {
+        return root.findOrCreateDirectories(path)
+            ?: throw IOException("Failed to find or create " + redactor.redact(path) + " in " +
+                    redactor.redact(root.uri))
+    }
 
-            Log.i(TAG, "Successfully moved $redactedSource to $redactedTarget")
-            sourceFile.delete()
+    private fun createFile(root: DocumentFile, path: List<String>, mimeType: String): DocumentFile {
+        require(path.isNotEmpty()) { "Path cannot be empty" }
 
-            targetFile
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to move $redactedSource to $userDir", e)
-            null
-        }
+        val redactedPath = redactor.redact(path)
+        val redactedRoot = redactor.redact(root.uri)
+        Log.d(TAG, "Creating $redactedPath with MIME type $mimeType in $redactedRoot")
+
+        return root.createNestedFile(mimeType, path)
+            ?: throw IOException("Failed to create file $redactedPath in $redactedRoot")
     }
 
     /**
-     * Move [sourceFile] to [targetDir].
+     * Open seekable file descriptor to [file].
      *
-     * @return The [DocumentFile] for the newly moved file.
+     * @throws IOException if [file] cannot be opened
      */
-    private fun moveFileToDir(sourceFile: DocumentFile, targetDir: DocumentFile): DocumentFile {
-        val targetFile = createFileInDir(targetDir, sourceFile.name!!, sourceFile.type!!)
+    fun openFile(file: DocumentFile, truncate: Boolean): ParcelFileDescriptor {
+        val truncParam = if (truncate) { "t" } else { "" }
+        return context.contentResolver.openFileDescriptor(file.uri, "rw$truncParam")
+            ?: throw IOException("Failed to open file at ${file.uri}")
+    }
 
+    /**
+     * Move [sourceFile] to [targetFile] via copy + delete.
+     *
+     * Both files must have already been created.
+     */
+    private fun copyAndDelete(sourceFile: DocumentFile, targetFile: DocumentFile) {
         try {
             openFile(sourceFile, false).use { sourcePfd ->
                 openFile(targetFile, true).use { targetPfd ->
@@ -70,7 +86,6 @@ class OutputDirUtils(private val context: Context, private val redactor: Redacto
             }
 
             sourceFile.delete()
-            return targetFile
         } catch (e: Exception) {
             targetFile.delete()
             throw e
@@ -78,42 +93,116 @@ class OutputDirUtils(private val context: Context, private val redactor: Redacto
     }
 
     /**
-     * Create [name] in the default output directory.
+     * Move [sourceTree]/[sourcePath] to [targetTree]/[targetPath].
      *
-     * @param name Should not contain a file extension
+     * If conditions allow for it, the move will be done efficiently (eg. rename() for file URIs and
+     * moveDocument() for DocumentsProvider URIs). Otherwise, the move is done by copying and then
+     * deleting the source file.
+     *
+     * @return The [DocumentFile] for the newly moved file.
+     */
+    private fun move(
+        sourceTree: DocumentFile,
+        sourcePath: List<String>,
+        targetTree: DocumentFile,
+        targetPath: List<String>,
+    ): DocumentFile {
+        require(targetPath.isNotEmpty()) { "Target path must not be empty" }
+
+        val sourceFile = getExistingPath(sourceTree, sourcePath)
+        val targetParentPath = targetPath.dropLast(1)
+        val targetParent = getOrCreateDirectory(targetTree, targetParentPath)
+
+        // Try to move efficiently if possible
+        try {
+            val targetFile = sourceFile.moveToDirectory(targetParent)
+            if (targetFile != null) {
+                val oldFilename = targetFile.name!!.substringBeforeLast('.')
+                val newFilename = targetPath.last()
+
+                if (oldFilename != newFilename && !targetFile.renameToPreserveExt(newFilename)) {
+                    // We intentionally don't report this error so that the user can be shown the
+                    // valid, but incorrectly named, target file instead of the now non-existent
+                    // source file.
+                    Log.w(TAG, "Failed to rename target file from " +
+                            redactor.redact(oldFilename) + " to "  + redactor.redact(newFilename))
+                }
+
+                return targetFile
+            } else {
+                Log.w(TAG, "Failed to efficiently move ${redactor.redact(sourceFile.uri)} to " +
+                        redactor.redact(targetParent.uri))
+            }
+        } catch (e: NotEfficientlyMovableException) {
+            // Intentionally omitting stack trace
+            Log.w(TAG, "${redactor.redact(sourceFile.uri)} cannot be efficiently moved to " +
+                    "${redactor.redact(targetParent.uri)}: ${e.message}")
+        }
+
+        val targetFile = createFile(targetTree, targetPath, sourceFile.type!!)
+        copyAndDelete(sourceFile, targetFile)
+        return targetFile
+    }
+
+    /**
+     * Create [path] in the default output directory.
+     *
+     * @param path The last element is the filename, which should not contain a file extension
      * @param mimeType Determines the file extension
      *
      * @throws IOException if the file could not be created in the default directory
      */
-    fun createFileInDefaultDir(name: String, mimeType: String): DocumentFile {
+    fun createFileInDefaultDir(path: List<String>, mimeType: String): DocumentFile {
         val defaultDir = DocumentFile.fromFile(prefs.defaultOutputDir)
-        return createFileInDir(defaultDir, name, mimeType)
+
+        return try {
+            createFile(defaultDir, path, mimeType)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to create file; using fallback path", e)
+
+            // If the failure is due to eg. running out of space, then there's nothing we can do and
+            // this will just fail the same way again. However, if the failure is due to eg. an
+            // intermediate path segment being a file instead of a directory, then at least the user
+            // will still have the recording, even if the directory structure is wrong.
+            createFile(defaultDir, getErrorFallbackPath(path), mimeType)
+        }
     }
 
     /**
-     * Create a new file with name [name] inside [dir].
+     * Try to move [sourceFile] to the user output directory at [path].
      *
-     * @param name Should not contain a file extension
-     * @param mimeType Determines the file extension
-     *
-     * @throws IOException if file creation fails
+     * @return Whether the user output directory is set and the file was successfully moved
      */
-    private fun createFileInDir(dir: DocumentFile, name: String, mimeType: String): DocumentFile {
-        Log.d(TAG, "Creating ${redactor.redact(name)} with MIME type $mimeType in ${dir.uri}")
+    fun tryMoveToOutputDir(sourceFile: DocumentFile, path: List<String>): DocumentFile? {
+        val userDir = prefs.outputDir?.let {
+            // Only returns null on API <21
+            DocumentFile.fromTreeUri(context, it)!!
+        } ?: DocumentFile.fromFile(prefs.defaultOutputDir)
 
-        return dir.createFile(mimeType, name)
-            ?: throw IOException("Failed to create file in ${dir.uri}")
-    }
+        val redactedSource = redactor.redact(sourceFile.uri)
 
-    /**
-     * Open seekable file descriptor to [file].
-     *
-     * @throws IOException if [file] cannot be opened
-     */
-    fun openFile(file: DocumentFile, truncate: Boolean): ParcelFileDescriptor {
-        val truncParam = if (truncate) { "t" } else { "" }
-        return context.contentResolver.openFileDescriptor(file.uri, "rw$truncParam")
-            ?: throw IOException("Failed to open file at ${file.uri}")
+        return try {
+            val targetFile = try {
+                move(sourceFile, emptyList(), userDir, path)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to move file; using fallback path", e)
+                move(sourceFile, emptyList(), userDir, getErrorFallbackPath(path))
+            }
+            val redactedTarget = redactor.redact(targetFile.uri)
+
+            Log.i(TAG, "Successfully moved $redactedSource to $redactedTarget")
+
+            try {
+                sourceFile.parentFile?.deleteIfEmptyDirRecursively()
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to clean up empty source directories", e)
+            }
+
+            targetFile
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to move $redactedSource to $userDir", e)
+            null
+        }
     }
 
     companion object {
@@ -121,14 +210,14 @@ class OutputDirUtils(private val context: Context, private val redactor: Redacto
 
         val NULL_REDACTOR = object : Redactor {
             override fun redact(msg: String): String = msg
-
-            override fun redact(uri: Uri): String = Uri.decode(uri.toString())
         }
     }
 
     interface Redactor {
         fun redact(msg: String): String
 
-        fun redact(uri: Uri): String
+        fun redact(uri: Uri): String = redact(Uri.decode(uri.toString()))
+
+        fun redact(path: List<String>): String = redact(path.joinToString("/"))
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryBottomSheetFragment.kt
@@ -44,15 +44,30 @@ class OutputDirectoryBottomSheetFragment : BottomSheetDialogFragment() {
         binding.selectNewDir.setOnClickListener {
             requestSafOutputDir.launch(null)
         }
+        binding.selectNewDir.setOnLongClickListener {
+            prefs.outputDir = null
+            refreshOutputDir()
+            true
+        }
 
         binding.editTemplate.setOnClickListener {
             FilenameTemplateDialogFragment().show(
                 parentFragmentManager.beginTransaction(), FilenameTemplateDialogFragment.TAG)
         }
+        binding.editTemplate.setOnLongClickListener {
+            prefs.filenameTemplate = null
+            refreshFilenameTemplate()
+            true
+        }
 
         binding.editRetention.setOnClickListener {
             FileRetentionDialogFragment().show(
                 parentFragmentManager.beginTransaction(), FileRetentionDialogFragment.TAG)
+        }
+        binding.editRetention.setOnLongClickListener {
+            prefs.outputRetention = null
+            refreshOutputRetention()
+            true
         }
 
         binding.reset.setOnClickListener {

--- a/app/src/main/java/com/chiller3/bcr/template/TemplateSyntaxHighlighter.kt
+++ b/app/src/main/java/com/chiller3/bcr/template/TemplateSyntaxHighlighter.kt
@@ -17,6 +17,8 @@ class TemplateSyntaxHighlighter(context: Context) {
         context, R.color.template_highlighting_variable_ref_arg)
     private val colorFallbackChars = getHarmonizedColor(
         context, R.color.template_highlighting_fallback_chars)
+    private val colorDirectorySeparator = getHarmonizedColor(
+        context, R.color.template_highlighting_directory_separator)
 
     fun highlight(
         spannable: Spannable,
@@ -67,6 +69,18 @@ class TemplateSyntaxHighlighter(context: Context) {
                     ForegroundColorSpan(colorVariableRefArg.accent),
                     templateStart + arg.range.first,
                     templateStart + arg.range.last + 1,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+            }
+        }
+
+        // Color directory separators last to ensure their visual prominence.
+        for ((i, c) in template.withIndex()) {
+            if (c == '/') {
+                spannable.setSpan(
+                    ForegroundColorSpan(colorDirectorySeparator.accent),
+                    templateStart + i,
+                    templateStart + i + 1,
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
                 )
             }

--- a/app/src/main/res/layout/dialog_text_input.xml
+++ b/app/src/main/res/layout/dialog_text_input.xml
@@ -28,5 +28,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/bottom_message"
+            style="?attr/materialAlertDialogBodyTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/abc_dialog_title_divider_material"
+            android:visibility="gone" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
     <color name="template_highlighting_variable_ref_name">#ff008000</color>
     <color name="template_highlighting_variable_ref_arg">#ff0000ff</color>
     <color name="template_highlighting_fallback_chars">#ffff00ff</color>
+    <color name="template_highlighting_directory_separator">#ffff0000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="filename_template_dialog_title">Filename template</string>
     <!-- NOTE: For the "supported_vars" annotation, the content MUST not be empty. Any string can go inside of it as a placeholder. -->
     <string name="filename_template_dialog_message">Enter a custom template for the output filename. Variables are specified with curly braces (eg. <annotation type="template">{var}</annotation>). Fallbacks are specified with square brackets (eg. <annotation type="template">[{contact_name}|Unknown]</annotation>).\n\nSupported variables: <annotation type="supported_vars">PLACEHOLDER</annotation>. See <annotation type="template_docs">the documentation</annotation> for a complete description of the syntax.</string>
+    <string name="filename_template_dialog_warning_subdirectories">Due to Android Storage Access Framework\'s poor performance, using subdirectories (<annotation type="template">/</annotation> character) may cause significant delays when saving the recording on some devices. The delay occurs at the end of the call and should not result in any loss of call audio.</string>
     <string name="filename_template_dialog_error_empty">Template cannot be empty</string>
     <string name="filename_template_dialog_error_unknown_variable">Unknown template variable: <annotation type="template">PLACEHOLDER</annotation></string>
     <string name="filename_template_dialog_error_has_argument">Variable cannot have an argument: <annotation type="template">PLACEHOLDER</annotation></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,7 +93,9 @@
     <string name="notification_channel_failure_desc">Alerts for errors during call recording</string>
     <string name="notification_channel_success_name">Success alerts</string>
     <string name="notification_channel_success_desc">Alerts for successful call recordings</string>
+    <string name="notification_recording_initializing">Call recording initializing</string>
     <string name="notification_recording_in_progress">Call recording in progress</string>
+    <string name="notification_recording_finalizing">Call recording finalizing</string>
     <string name="notification_recording_paused">Call recording paused</string>
     <string name="notification_recording_on_hold">Call on hold</string>
     <string name="notification_recording_failed">Failed to record call</string>


### PR DESCRIPTION
This commit adds support for using directory separators `/` in the filename template. The separators are only allowed in the parts of the template controlled by the user (eg. outside of variables or inside the `${date:<arg>}` argument). If the separator appears in any other variable, like the caller ID, it is replaced with an underscore. While `.` and
`..` are properly handled in AOSP's `FileSystemProvider` (the default `DocumentsProvider` used when the user selects a directory on the internal storage or SD card), BCR will silently omit these path segments to avoid potential security issues when a 3rd party cloud app output directory is chosen.

All existing features are supported when subdirectories are used, including the file retention feature. However, due to the absurd slowness of Android's Storage Access Framework, using subdirectories may cause the saving of the recording (at the end of the call) to take a significant amount of time.

The slowness of SAF is primarily due to slow directory traversal and file lookup by path. SAF has no way to access a file directly. It must start from the user's chosen tree (output directory) and iterate through the path, one segment at a time. At each directory level, it must scan through each child, `stat()`'ing every one, until the next path segment is found. This is true even with the most optimized `ContentResolver` query, like we already do in `findFileFast()`.

On devices with "good" SAF implementations, like the Pixel series, I measured between 50-100x slowdown compared to operating with raw files for these types of operations. On other devices, I suspect it will be even slower. We know from past bug reports where some devices take 8+ seconds just to check if a file exists via SAF. Those devices will likely have delays of multiple minutes if the user chooses to use subdirectories. There's nothing BCR can do to work around that.

Also, SAF has basically no guarantees with regards to safety when creating files. There are TOCTTOU issues everywhere. If the user has anything else writing to the same locations as BCR at the same time, there will likely be trouble.

Fixes: #357