### PR TITLE
Fixes to compile under SDK 34

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderTileService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderTileService.kt
@@ -44,7 +44,7 @@ class RecorderTileService : TileService(), SharedPreferences.OnSharedPreferenceC
         refreshTileState()
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         refreshTileState()
     }
 

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -199,8 +199,9 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
         return false
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         when {
+            key == null -> return
             // Update the switch state if it was toggled outside of the preference (eg. from the
             // quick settings toggle)
             key == prefCallRecording.key -> {


### PR DESCRIPTION
Fixes #376, hope I did it right.

For full API 34 compatibility the following should be fixed: <https://developer.android.com/reference/kotlin/android/service/quicksettings/TileService#startactivityandcollapse_1>

`fun startActivityAndCollapse(intent: Intent!): Unit` is deprecated in favor of `fun startActivityAndCollapse(pendingIntent: PendingIntent): Unit`