### PR TITLE
Add shortcut for opening the output directory in DocumentsUI

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/extension/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/UriExtensions.kt
@@ -2,14 +2,17 @@ package com.chiller3.bcr.extension
 
 import android.content.ContentResolver
 import android.net.Uri
+import android.provider.DocumentsContract
 import android.telecom.PhoneAccount
+
+val DOCUMENTSUI_AUTHORITY = "com.android.externalstorage.documents"
 
 val Uri.formattedString: String
     get() = when (scheme) {
         ContentResolver.SCHEME_FILE -> path!!
         ContentResolver.SCHEME_CONTENT -> {
             val prefix = when (authority) {
-                "com.android.externalstorage.documents" -> ""
+                DOCUMENTSUI_AUTHORITY -> ""
                 // Include the authority to reduce ambiguity when this isn't a SAF URI provided by
                 // Android's local filesystem document provider
                 else -> "[$authority] "
@@ -34,3 +37,10 @@ val Uri.phoneNumber: String?
         PhoneAccount.SCHEME_TEL -> schemeSpecificPart
         else -> null
     }
+
+fun Uri.safTreeToDocument(): Uri {
+    require(scheme == ContentResolver.SCHEME_CONTENT) { "Not a content URI" }
+
+    val documentId = DocumentsContract.getTreeDocumentId(this)
+    return DocumentsContract.buildDocumentUri(authority, documentId)
+}

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -1,5 +1,6 @@
 package com.chiller3.bcr.settings
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
@@ -21,6 +22,7 @@ import com.chiller3.bcr.output.Retention
 import com.chiller3.bcr.rule.RecordRulesActivity
 import com.chiller3.bcr.view.LongClickablePreference
 import com.chiller3.bcr.view.OnPreferenceLongClickListener
+import com.google.android.material.snackbar.Snackbar
 
 class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChangeListener,
     Preference.OnPreferenceClickListener, OnPreferenceLongClickListener,
@@ -28,7 +30,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
     private lateinit var prefs: Preferences
     private lateinit var prefCallRecording: SwitchPreferenceCompat
     private lateinit var prefRecordRules: Preference
-    private lateinit var prefOutputDir: Preference
+    private lateinit var prefOutputDir: LongClickablePreference
     private lateinit var prefOutputFormat: Preference
     private lateinit var prefInhibitBatteryOpt: SwitchPreferenceCompat
     private lateinit var prefVersion: LongClickablePreference
@@ -68,6 +70,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
 
         prefOutputDir = findPreference(Preferences.PREF_OUTPUT_DIR)!!
         prefOutputDir.onPreferenceClickListener = this
+        prefOutputDir.onPreferenceLongClickListener = this
         refreshOutputDir()
 
         prefOutputFormat = findPreference(Preferences.PREF_OUTPUT_FORMAT)!!
@@ -189,6 +192,18 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
 
     override fun onPreferenceLongClick(preference: Preference): Boolean {
         when (preference) {
+            prefOutputDir -> {
+                try {
+                    startActivity(prefs.outputDirOrDefaultIntent)
+                } catch (e: ActivityNotFoundException) {
+                    Snackbar.make(
+                        requireView(),
+                        R.string.documentsui_not_found,
+                        Snackbar.LENGTH_LONG,
+                    ).show()
+                }
+                return true
+            }
             prefVersion -> {
                 prefs.isDebugMode = !prefs.isDebugMode
                 refreshVersion()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="pref_record_rules_desc">Configure which calls should be automatically recorded.</string>
 
     <string name="pref_output_dir_name">Output directory</string>
-    <string name="pref_output_dir_desc">Pick a directory to store recordings.</string>
+    <string name="pref_output_dir_desc">Pick a directory to store recordings. Long press to open in file manager.</string>
 
     <string name="pref_output_format_name">Output format</string>
     <string name="pref_output_format_desc">Select an encoding format for the recordings.</string>
@@ -118,4 +118,7 @@
 
     <!-- Quick settings tile -->
     <string name="quick_settings_label">Call recording</string>
+
+    <!-- Snackbar alerts -->
+    <string name="documentsui_not_found">Android\'s builtin file manager (DocumentsUI) is unavailable.</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -16,7 +16,7 @@
             app:summary="@string/pref_record_rules_desc"
             app:iconSpaceReserved="false" />
 
-        <Preference
+        <com.chiller3.bcr.view.LongClickablePreference
             app:key="output_dir"
             app:persistent="false"
             app:title="@string/pref_output_dir_name"


### PR DESCRIPTION
Long pressing the output directory preference will open the file manager. This normally uses DocumentsUI, but if any 3rd party file manager supports receiving intents with the `vnd.android.document/directory` type, then the user will be able to choose from the system or 3rd party file manager.

Issue: #135