### PR TITLE
Persist next notification ID in the shared preferences

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -32,16 +32,6 @@ class Notifications(
 
         private val LEGACY_CHANNEL_IDS = arrayOf("alerts")
 
-        /** Incremented for each new notification. */
-        private var nextNotificationId = 1
-
-        /** Get a new unique notification ID. */
-        fun allocateNotificationId(): Int {
-            val id = nextNotificationId
-            ++nextNotificationId
-            return id
-        }
-
         /** For access to system/internal resource values. */
         private val systemRes = Resources.getSystem()
 
@@ -80,6 +70,7 @@ class Notifications(
         }
     }
 
+    private val prefs = Preferences(context)
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
 
     /**
@@ -199,7 +190,7 @@ class Notifications(
         file: OutputFile?,
         additionalFiles: List<OutputFile>,
     ) {
-        val notificationId = allocateNotificationId()
+        val notificationId = prefs.nextNotificationId
 
         val notification = Notification.Builder(context, channel).run {
             val text = buildString {

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -41,6 +41,7 @@ class Preferences(private val context: Context) {
         private const val PREF_FORMAT_PARAM_PREFIX = "codec_param_"
         const val PREF_OUTPUT_RETENTION = "output_retention"
         const val PREF_SAMPLE_RATE = "sample_rate"
+        private const val PREF_NEXT_NOTIFICATION_ID = "next_notification_id"
 
         // Defaults
         val DEFAULT_FILENAME_TEMPLATE = Template(
@@ -300,4 +301,14 @@ class Preferences(private val context: Context) {
     var writeMetadata: Boolean
         get() = prefs.getBoolean(PREF_WRITE_METADATA, false)
         set(enabled) = prefs.edit { putBoolean(PREF_WRITE_METADATA, enabled) }
+
+    /**
+     * Get a unique notification ID that increments on every call.
+     */
+    val nextNotificationId: Int
+        get() = synchronized(context.applicationContext) {
+            val nextId = prefs.getInt(PREF_NEXT_NOTIFICATION_ID, 0)
+            prefs.edit { putInt(PREF_NEXT_NOTIFICATION_ID, nextId + 1) }
+            nextId
+        }
 }

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -35,7 +35,9 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
      * Notification ID to use for the foreground service. Throughout the lifetime of the service, it
      * may be associated with different calls. It is not cancelled until all recorders exit.
      */
-    private val foregroundNotificationId = Notifications.allocateNotificationId()
+    private val foregroundNotificationId by lazy {
+        prefs.nextNotificationId
+    }
 
     /**
      * Notification IDs and their associated recorders. This indicates the desired state of the
@@ -243,7 +245,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
             val notificationId = if (notificationIdsToRecorders.isEmpty()) {
                 foregroundNotificationId
             } else {
-                Notifications.allocateNotificationId()
+                prefs.nextNotificationId
             }
             notificationIdsToRecorders[notificationId] = recorder
 


### PR DESCRIPTION
When Android kills and relaunches BCR, old notifications may not be cleared. This could cause unexpected behavior if a notification ID is reused.