### PR TITLE
OutputFilenameGenerator: Add missing return keyword when getting `direction` variable

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/output/OutputFilenameGenerator.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputFilenameGenerator.kt
@@ -110,7 +110,7 @@ class OutputFilenameGenerator(
 
                 return formatter.format(metadata.timestamp)
             }
-            "direction" -> metadata.direction?.toString()
+            "direction" -> return metadata.direction?.toString()
             "sim_slot" -> {
                 // Only append SIM slot ID if the device has multiple active SIMs
                 if (metadata.simCount != null && metadata.simCount > 1) {


### PR DESCRIPTION
Fixes: #394