### PR TITLE
Disable gradle verification for sources and javadocs jars

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,10 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+      <trusted-artifacts>
+         <trust file=".*-javadoc[.]jar" regex="true" />
+         <trust file=".*-sources[.]jar" regex="true" />
+      </trusted-artifacts>
    </configuration>
    <components>
       <component group="androidx.activity" name="activity" version="1.7.2">


### PR DESCRIPTION
There's no sane way to add the checksums for these in the metadata file and they don't get compiled into the final binary anyway. This fixes API documentation and source code not showing up in Android Studio. This is gradle's recommended workaround for this issue [1].

[1] https://docs.gradle.org/current/userguide/dependency_verification.html#sec:skipping-javadocs