### PR TITLE
Standardize OK and Cancel buttons; use defined in Android resources

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/dialog/FileRetentionDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/dialog/FileRetentionDialogFragment.kt
@@ -71,11 +71,11 @@ class FileRetentionDialogFragment : DialogFragment() {
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.file_retention_dialog_title)
             .setView(binding.root)
-            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+            .setPositiveButton(android.R.string.ok) { _, _ ->
                 prefs.outputRetention = retention!!
                 success = true
             }
-            .setNegativeButton(R.string.dialog_action_cancel, null)
+            .setNegativeButton(android.R.string.cancel, null)
             .create()
             .apply {
                 setCanceledOnTouchOutside(false)

--- a/app/src/main/java/com/chiller3/bcr/dialog/FilenameTemplateDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/dialog/FilenameTemplateDialogFragment.kt
@@ -116,11 +116,11 @@ class FilenameTemplateDialogFragment : DialogFragment() {
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.filename_template_dialog_title)
             .setView(binding.root)
-            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+            .setPositiveButton(android.R.string.ok) { _, _ ->
                 prefs.filenameTemplate = template!!
                 success = true
             }
-            .setNegativeButton(R.string.dialog_action_cancel, null)
+            .setNegativeButton(android.R.string.cancel, null)
             .setNeutralButton(R.string.filename_template_dialog_action_reset_to_default) { _, _ ->
                 prefs.filenameTemplate = null
                 success = true

--- a/app/src/main/java/com/chiller3/bcr/dialog/FormatParamDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/dialog/FormatParamDialogFragment.kt
@@ -99,11 +99,11 @@ class FormatParamDialogFragment : DialogFragment() {
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.format_param_dialog_title)
             .setView(binding.root)
-            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+            .setPositiveButton(android.R.string.ok) { _, _ ->
                 prefs.setFormatParam(format, value!!)
                 success = true
             }
-            .setNegativeButton(R.string.dialog_action_cancel, null)
+            .setNegativeButton(android.R.string.cancel, null)
             .create()
             .apply {
                 setCanceledOnTouchOutside(false)

--- a/app/src/main/java/com/chiller3/bcr/dialog/MessageDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/dialog/MessageDialogFragment.kt
@@ -35,7 +35,7 @@ class MessageDialogFragment : DialogFragment() {
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(arguments.getCharSequence(ARG_TITLE))
             .setMessage(arguments.getCharSequence(ARG_MESSAGE))
-            .setPositiveButton(R.string.dialog_action_ok) { _, _ ->
+            .setPositiveButton(android.R.string.ok) { _, _ ->
                 success = true
             }
             .create()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -82,10 +82,6 @@
     <string name="format_param_bitrate">%s kbps</string>
     <string name="format_param_compression_level">Komprimierungsstufe %s</string>
 
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">OK</string>
-    <string name="dialog_action_cancel">Abbrechen</string>
-
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Hintergrunddienste</string>
     <string name="notification_channel_persistent_desc">Persistierende Benachrichtigung für Aufnahmen im Hintergrund</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -84,10 +84,6 @@
     <string name="format_param_bitrate">%s kbps</string>
     <string name="format_param_compression_level">Poziom %s</string>
 
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">OK</string>
-    <string name="dialog_action_cancel">Anuluj</string>
-
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Usługi w tle</string>
     <string name="notification_channel_persistent_desc">Stałe powiadomienie o nagrywaniu rozmów w tle</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -67,9 +67,6 @@
     <!-- Format parameter -->
     <string name="format_param_bitrate">%s kbps</string>
     <string name="format_param_compression_level">Уровень %s</string>
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">ОК</string>
-    <string name="dialog_action_cancel">Отмена</string>
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Фоновые сервисы</string>
     <string name="notification_channel_persistent_desc">Постоянное уведомление о записи разговоров в фоновом режиме</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -86,10 +86,6 @@
     <string name="format_param_bitrate">%s kbps</string>
     <string name="format_param_compression_level">Seviye %s</string>
 
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">Tamam</string>
-    <string name="dialog_action_cancel">İptal</string>
-
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Arka plan servisleri</string>
     <string name="notification_channel_persistent_desc">Arka plan arama kaydı için kalıcı bildirim</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -85,10 +85,6 @@
     <string name="format_param_bitrate">%s кбіт/с</string>
     <string name="format_param_compression_level">Рівень %s</string>
 
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">Гаразд</string>
-    <string name="dialog_action_cancel">Скасувати</string>
-
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Фонові служби</string>
     <string name="notification_channel_persistent_desc">Постійне сповіщення про фоновий запис дзвінка</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -68,8 +68,6 @@
     <string name="format_param_dialog_message">输入数值范围: %1$s ~ %2$s</string>
     <string name="format_param_bitrate">%s bkps</string>
     <string name="format_param_compression_level">Level %s</string>
-    <string name="dialog_action_ok">确定</string>
-    <string name="dialog_action_cancel">取消</string>
 
     <!-- Filename template dialog -->
     <string name="filename_template_dialog_title">文件名模板</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -82,10 +82,6 @@
     <string name="format_param_bitrate">%s kbps</string>
     <string name="format_param_compression_level">等級 %s</string>
 
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">確定</string>
-    <string name="dialog_action_cancel">取消</string>
-
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">背景服務</string>
     <string name="notification_channel_persistent_desc">持續性通知，用於背景通話錄音</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,10 +86,6 @@
     <string name="format_param_bitrate">%s kbps</string>
     <string name="format_param_compression_level">Level %s</string>
 
-    <!-- Dialogs -->
-    <string name="dialog_action_ok">OK</string>
-    <string name="dialog_action_cancel">Cancel</string>
-
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Background services</string>
     <string name="notification_channel_persistent_desc">Persistent notification for background call recording</string>


### PR DESCRIPTION
OK and Cancel are already defined in [Android resources](https://developer.android.com/reference/android/R.string), so no need for custom implementation and maintaining translations of them.