### PR TITLE
Launch Android Settings to re-enable battery optimization

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -58,4 +58,11 @@ object Permissions {
         Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
         Uri.fromParts("package", context.packageName, null),
     )
+
+    /**
+     * Get intent for opening the battery optimization settings so the user can re-enable it.
+     */
+    fun getBatteryOptSettingsIntent() = Intent(
+        Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS,
+    )
 }

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -135,28 +135,26 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
     private fun refreshInhibitBatteryOptState() {
         val inhibiting = Permissions.isInhibitingBatteryOpt(requireContext())
         prefInhibitBatteryOpt.isChecked = inhibiting
-        prefInhibitBatteryOpt.isEnabled = !inhibiting
     }
 
     override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-        // No need to validate runtime permissions when disabling a feature
-        if (newValue == false) {
-            return true
-        }
-
         val context = requireContext()
 
         when (preference) {
-            prefCallRecording -> if (Permissions.haveRequired(context)) {
+            prefCallRecording -> if (newValue == false || Permissions.haveRequired(context)) {
                 return true
             } else {
                 // Ask for optional permissions the first time only
                 requestPermissionRequired.launch(Permissions.REQUIRED + Permissions.OPTIONAL)
             }
-            // This is only reachable if battery optimization is not already inhibited
-            prefInhibitBatteryOpt -> requestInhibitBatteryOpt.launch(
-                Permissions.getInhibitBatteryOptIntent(requireContext())
-            )
+            prefInhibitBatteryOpt -> {
+                if (newValue == true) {
+                    requestInhibitBatteryOpt.launch(
+                        Permissions.getInhibitBatteryOptIntent(requireContext()))
+                } else {
+                    startActivity(Permissions.getBatteryOptSettingsIntent())
+                }
+            }
         }
 
         return false


### PR DESCRIPTION
Currently, BCR will just gray out the `Disable battery optimization` option after it is enabled because Android does not provide a way for apps to re-enable optimizations.

This isn't very user-friendly, so this commit updates the option to never be grayed out, but instead, take the user to the appropriate page in Android's Settings.

Fixes: #422