### PR TITLE
Add limited support for call redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
   * A notification is required for running the call recording service in foreground mode or else Android will not allow access to the call audio stream.
 * `READ_CALL_LOG` (**optional**)
   * If allowed, the name as shown in the call log can be added to the output filename.
+  * This is also required to show the correct phone number when using call redirection apps.
 * `READ_CONTACTS` (**optional**)
   * If allowed, the contact name can be added to the output filename. It also allows auto-record rules to be set per contact.
 * `READ_PHONE_STATE` (**optional**)
@@ -98,6 +99,20 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
   * If vibration is enabled for BCR's notifications in Android's settings, BCR will perform the vibration. Android itself does not respect the vibration option when a phone call is active.
 
 Note that `INTERNET` is _not_ in the list. BCR does not and will never access the network. BCR will never communicate with other apps either, except if the user explicitly taps on the `Open` or `Share` buttons in the notification shown when a recording completes. In that scenario, the target app is granted access to that single recording only.
+
+## Call redirection
+
+BCR has limited support for call redirection apps, like Google Voice. Redirected calls can be recorded only if the call redirection service uses standard telephone calls behind the scenes (instead of VOIP).
+
+There are several limitations when recording redirected calls compared to regular calls:
+
+* The call must not be a conference call. Otherwise, the filename will only show the call redirection service's proxy phone number.
+* Auto-record rules will not work properly. Redirected calls will never match any rules for specified contacts and will only match the `All other calls` rule.
+* During the call, BCR's notification will only show the call redirection service's proxy phone number.
+* BCR must be granted the call logs permission.
+* The dialer app must put the original phone number into the system call log. The AOSP and Google dialer apps do, but other OEM dialer apps might not.
+
+These limitations exist because when a call is redirected, only the dialer app itself is aware of the original phone number. The Android telephony system is not aware of it. BCR can only find the original phone number by searching the system call log when the dialer adds the entry at the end of the call.
 
 ## Filename template
 

--- a/app/src/main/java/com/chiller3/bcr/output/PhoneNumber.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/PhoneNumber.kt
@@ -6,7 +6,7 @@ import android.telephony.TelephonyManager
 import android.util.Log
 import java.util.Locale
 
-class PhoneNumber(private val number: String) {
+data class PhoneNumber(private val number: String) {
     fun format(context: Context, format: Format) = when (format) {
         Format.DIGITS_ONLY -> number.filter { Character.digit(it, 10) != -1 }
         Format.COUNTRY_SPECIFIC -> {


### PR DESCRIPTION
Android 10 added the `CallRedirectionService` API, which allows a third party app to process outgoing calls made from the system's dialer. Some call redirection services, like Google Voice, use phone calls under the hood instead of VOIP. These calls can be recorded by BCR, but would previously show the service's proxy phone number.

Unfortunately, with the way Android's APIs are designed, the only thing that's aware of the original phone number is the dialer. We have no way of querying that in BCR until the call ends and the dialer writes the entry to the call log. This commit implements support for looking up the phone number from the call log.

This lookup functionality only works for non-conference calls and the call will always be classified as `All other calls` in the auto-record rules.

Fixes: #443