### PR TITLE
Enable memory tagging extensions for ARMv9 devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:memtagMode="sync"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BCR"


### PR DESCRIPTION
While BCR itself has no native code, the system media codecs do and we've run into memory corruption issues in the past (eg. the FLAC encoder can sometimes segfault if audio buffer timestamps are not set correctly).

Enabling MTE won't really make a difference security-wise for BCR. We never parse any untrusted inputs. But it might help catch potential issues in the media stack.