### PR TITLE
Automatically detect supported sample rates for each codec

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -299,6 +299,22 @@ android.applicationVariants.all {
         }
     }
 
+    val configXml = tasks.register("configXml${capitalized}") {
+        inputs.property("variant.applicationId", variant.applicationId)
+
+        val outputFile = variantDir.map { it.file("config-${variant.applicationId}.xml") }
+        outputs.file(outputFile)
+
+        doLast {
+            outputFile.get().asFile.writeText("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <config>
+                    <hidden-api-whitelisted-app package="${variant.applicationId}" />
+                </config>
+            """.trimIndent())
+        }
+    }
+
     val addonD = tasks.register("addonD${capitalized}") {
         inputs.property("variant.applicationId", variant.applicationId)
 
@@ -357,6 +373,9 @@ android.applicationVariants.all {
         }
         from(permissionsXml.map { it.outputs }) {
             into("system/etc/permissions")
+        }
+        from(configXml.map { it.outputs }) {
+            into("system/etc/sysconfig")
         }
         from(variant.outputs.map { it.outputFile }) {
             into("system/priv-app/${variant.applicationId}")

--- a/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
@@ -1,5 +1,6 @@
 package com.chiller3.bcr.extension
 
+import android.annotation.SuppressLint
 import android.media.AudioFormat
 import android.os.Build
 
@@ -11,3 +12,14 @@ val AudioFormat.frameSizeInBytesCompat: Int
         assert(encoding == AudioFormat.ENCODING_PCM_16BIT)
         2 * channelCount
     }
+
+// Static extension functions are currently not supported in Kotlin. Also, we install a sysconfig
+// file to allow access to these hidden fields.
+
+@SuppressLint("SoonBlockedPrivateApi")
+val SAMPLE_RATE_HZ_MIN_COMPAT: Int =
+    AudioFormat::class.java.getDeclaredField("SAMPLE_RATE_HZ_MIN").getInt(null)
+
+@SuppressLint("SoonBlockedPrivateApi")
+val SAMPLE_RATE_HZ_MAX_COMPAT: Int =
+    AudioFormat::class.java.getDeclaredField("SAMPLE_RATE_HZ_MAX").getInt(null)

--- a/app/src/main/java/com/chiller3/bcr/format/AacFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/AacFormat.kt
@@ -7,8 +7,12 @@ import android.media.MediaFormat
 import android.media.MediaMuxer
 import java.io.FileDescriptor
 
-object AacFormat : Format() {
+class AacFormat : Format() {
     override val name: String = "M4A/AAC"
+    // https://datatracker.ietf.org/doc/html/rfc6381#section-3.1
+    override val mimeTypeContainer: String = "audio/mp4"
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_AAC
+    override val passthrough: Boolean = false
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.Bitrate,
         // The format has no hard limits, so the lower bound is ffmpeg's recommended minimum bitrate
@@ -24,16 +28,8 @@ object AacFormat : Format() {
             128_000u,
         ),
     )
-    override val sampleRateInfo: SampleRateInfo = DiscreteSampleRateInfo(
-        // This what Android's C2 software encoder (C2SoftAacEnc.cpp) supports.
-        uintArrayOf(8_000u, 11_025u, 12_000u, 16_000u, 22_050u, 24_000u, 32_000u, 44_100u, 48_000u),
-        16_000u,
-    )
-    // https://datatracker.ietf.org/doc/html/rfc6381#section-3.1
-    override val mimeTypeContainer: String = "audio/mp4"
-    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_AAC
-    override val passthrough: Boolean = false
-    override val supported: Boolean = true
+    override val sampleRateInfo: SampleRateInfo =
+        SampleRateInfo.fromCodec(baseMediaFormat, 16_000u)
 
     override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {

--- a/app/src/main/java/com/chiller3/bcr/format/AmrNbFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/AmrNbFormat.kt
@@ -5,8 +5,11 @@ package com.chiller3.bcr.format
 import android.media.MediaFormat
 import java.io.FileDescriptor
 
-data object AmrNbFormat : Format() {
+class AmrNbFormat : Format() {
     override val name: String = "AMR-NB"
+    override val mimeTypeContainer: String = "audio/amr"
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_AMR_NB
+    override val passthrough: Boolean = false
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.Bitrate,
         4_750u..12_200u,
@@ -19,14 +22,8 @@ data object AmrNbFormat : Format() {
             12_200u,
         ),
     )
-    override val sampleRateInfo: SampleRateInfo = DiscreteSampleRateInfo(
-        uintArrayOf(8_000u),
-        8_000u,
-    )
-    override val mimeTypeContainer: String = "audio/amr"
-    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_AMR_NB
-    override val passthrough: Boolean = false
-    override val supported: Boolean = true
+    override val sampleRateInfo: SampleRateInfo =
+        SampleRateInfo.fromCodec(baseMediaFormat, 8_000u)
 
     override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {

--- a/app/src/main/java/com/chiller3/bcr/format/AmrWbFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/AmrWbFormat.kt
@@ -5,8 +5,11 @@ package com.chiller3.bcr.format
 import android.media.MediaFormat
 import java.io.FileDescriptor
 
-data object AmrWbFormat : Format() {
+class AmrWbFormat : Format() {
     override val name: String = "AMR-WB"
+    override val mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_AMR_WB
+    override val mimeTypeAudio: String = mimeTypeContainer
+    override val passthrough: Boolean = false
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.Bitrate,
         6_600u..23_850u,
@@ -19,14 +22,8 @@ data object AmrWbFormat : Format() {
             23_850u,
         ),
     )
-    override val sampleRateInfo: SampleRateInfo = DiscreteSampleRateInfo(
-        uintArrayOf(16_000u),
-        16_000u,
-    )
-    override val mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_AMR_WB
-    override val mimeTypeAudio: String = mimeTypeContainer
-    override val passthrough: Boolean = false
-    override val supported: Boolean = true
+    override val sampleRateInfo: SampleRateInfo =
+        SampleRateInfo.fromCodec(baseMediaFormat, 16_000u)
 
     override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {

--- a/app/src/main/java/com/chiller3/bcr/format/FlacFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/FlacFormat.kt
@@ -5,8 +5,11 @@ package com.chiller3.bcr.format
 import android.media.MediaFormat
 import java.io.FileDescriptor
 
-object FlacFormat : Format() {
+class FlacFormat : Format() {
     override val name: String = "FLAC"
+    override val mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_FLAC
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_FLAC
+    override val passthrough: Boolean = false
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.CompressionLevel,
         0u..8u,
@@ -14,15 +17,8 @@ object FlacFormat : Format() {
         8u,
         uintArrayOf(0u, 5u, 8u),
     )
-    override val sampleRateInfo: SampleRateInfo = RangedSampleRateInfo(
-        1u..655_350u,
-        16_000u,
-        uintArrayOf(8_000u, 16_000u, 48_000u),
-    )
-    override val mimeTypeContainer: String = MediaFormat.MIMETYPE_AUDIO_FLAC
-    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_FLAC
-    override val passthrough: Boolean = false
-    override val supported: Boolean = true
+    override val sampleRateInfo: SampleRateInfo =
+        SampleRateInfo.fromCodec(baseMediaFormat, 16_000u)
 
     override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {

--- a/app/src/main/java/com/chiller3/bcr/format/Format.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/Format.kt
@@ -2,6 +2,7 @@ package com.chiller3.bcr.format
 
 import android.media.AudioFormat
 import android.media.MediaFormat
+import android.util.Log
 import com.chiller3.bcr.Preferences
 import com.chiller3.bcr.extension.frameSizeInBytesCompat
 import java.io.FileDescriptor
@@ -9,12 +10,6 @@ import java.io.FileDescriptor
 sealed class Format {
     /** User-facing name of the format. */
     abstract val name: String
-
-    /** Details about the format parameter range and default value. */
-    abstract val paramInfo: FormatParamInfo
-
-    /** Defaults about the supported sample rates. */
-    abstract val sampleRateInfo: SampleRateInfo
 
     /** The MIME type of the container storing the encoded audio stream. */
     abstract val mimeTypeContainer: String
@@ -29,8 +24,17 @@ sealed class Format {
     /** Whether the format takes the PCM samples as is without encoding. */
     abstract val passthrough: Boolean
 
-    /** Whether the format is supported on the current device. */
-    abstract val supported: Boolean
+    /** Details about the format parameter range and default value. */
+    abstract val paramInfo: FormatParamInfo
+
+    /** Defaults about the supported sample rates. */
+    abstract val sampleRateInfo: SampleRateInfo
+
+    /** Bare minimum [MediaFormat] containing only [MediaFormat.KEY_MIME]. */
+    protected val baseMediaFormat: MediaFormat
+        get() = MediaFormat().apply {
+            setString(MediaFormat.KEY_MIME, mimeTypeAudio)
+        }
 
     /**
      * Create a [MediaFormat] representing the encoded audio with parameters matching the specified
@@ -47,8 +51,7 @@ sealed class Format {
             paramInfo.validate(param)
         }
 
-        val format = MediaFormat().apply {
-            setString(MediaFormat.KEY_MIME, mimeTypeAudio)
+        val format = baseMediaFormat.apply {
             setInteger(MediaFormat.KEY_CHANNEL_COUNT, audioFormat.channelCount)
             setInteger(MediaFormat.KEY_SAMPLE_RATE, audioFormat.sampleRate)
             setInteger(KEY_X_FRAME_SIZE_IN_BYTES, audioFormat.frameSizeInBytesCompat)
@@ -90,17 +93,31 @@ sealed class Format {
     abstract fun getContainer(fd: FileDescriptor): Container
 
     companion object {
+        private val TAG = Format::class.java.simpleName
+
         const val KEY_X_FRAME_SIZE_IN_BYTES = "x-frame-size-in-bytes"
 
-        val all: Array<Format> = arrayOf(
-            OpusFormat,
-            AacFormat,
-            FlacFormat,
-            WaveFormat,
-            AmrWbFormat,
-            AmrNbFormat,
-        )
-        private val default: Format = all.first { it.supported }
+        val all: List<Format> by lazy {
+            val formats = mutableListOf<Format>()
+
+            for (constructor in arrayOf(
+                ::OpusFormat,
+                ::AacFormat,
+                ::FlacFormat,
+                { WaveFormat },
+                ::AmrWbFormat,
+                ::AmrNbFormat,
+            )) {
+                try {
+                    formats.add(constructor())
+                } catch (e: IllegalArgumentException) {
+                    Log.w(TAG, "Failed to initialize with $constructor", e)
+                }
+            }
+
+            formats
+        }
+        private val default: Format = all.first()
 
         /** Find output format by name. */
         fun getByName(name: String): Format? = all.find { it.name == name }
@@ -112,11 +129,8 @@ sealed class Format {
          * sample rate, if set, is set to the nearest valid value.
          */
         fun fromPreferences(prefs: Preferences): Triple<Format, UInt?, UInt?> {
-            // Use the saved format if it is valid and supported on the current device. Otherwise,
-            // fall back to the default.
-            val format = prefs.format
-                ?.let { if (it.supported) { it } else { null } }
-                ?: default
+            // Use the saved format if it is (still) valid.
+            val format = prefs.format ?: default
 
             // Convert the saved value to the nearest valid value (eg. in case the bitrate range is
             // changed in a future version).

--- a/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
@@ -8,8 +8,18 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import java.io.FileDescriptor
 
-object OpusFormat : Format() {
+class OpusFormat : Format() {
+    init {
+        require(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            "Only supported on Android 10 and newer"
+        }
+    }
+
     override val name: String = "OGG/Opus"
+    // https://datatracker.ietf.org/doc/html/rfc7845#section-9
+    override val mimeTypeContainer: String = "audio/ogg"
+    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_OPUS
+    override val passthrough: Boolean = false
     override val paramInfo: FormatParamInfo = RangedParamInfo(
         RangedParamType.Bitrate,
         6_000u..510_000u,
@@ -24,16 +34,8 @@ object OpusFormat : Format() {
             48_000u,
         ),
     )
-    override val sampleRateInfo: SampleRateInfo = DiscreteSampleRateInfo(
-        // This what Android's C2 software encoder (C2SoftOpusEnc.cpp) supports.
-        uintArrayOf(8_000u, 12_000u, 16_000u, 24_000u, 48_000u),
-        16_000u,
-    )
-    // https://datatracker.ietf.org/doc/html/rfc7845#section-9
-    override val mimeTypeContainer: String = "audio/ogg"
-    override val mimeTypeAudio: String = MediaFormat.MIMETYPE_AUDIO_OPUS
-    override val passthrough: Boolean = false
-    override val supported: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+    override val sampleRateInfo: SampleRateInfo =
+        SampleRateInfo.fromCodec(baseMediaFormat, 16_000u)
 
     override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         mediaFormat.apply {

--- a/app/src/main/java/com/chiller3/bcr/format/SampleRateInfo.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/SampleRateInfo.kt
@@ -3,11 +3,13 @@
 package com.chiller3.bcr.format
 
 import android.content.Context
+import android.media.MediaCodecList
+import android.media.MediaFormat
 import com.chiller3.bcr.R
 
 sealed class SampleRateInfo(
     val default: UInt,
-    /** Handful of handpicked sample rate choices to show in the UI as presets. */
+    /** Fixed sample rate choices to show in the UI as presets. */
     val presets: UIntArray,
 ) {
     /**
@@ -27,22 +29,79 @@ sealed class SampleRateInfo(
      */
     fun format(context: Context, rate: UInt): String =
         context.getString(R.string.format_sample_rate, rate.toString())
+
+    companion object {
+        fun fromCodec(format: MediaFormat, tryDefault: UInt): SampleRateInfo {
+            val codecList = MediaCodecList(MediaCodecList.REGULAR_CODECS)
+
+            for (info in codecList.codecInfos) {
+                if (!info.isEncoder) {
+                    continue
+                }
+
+                val capabilities = try {
+                    info.getCapabilitiesForType(format.getString(MediaFormat.KEY_MIME))
+                } catch (e: IllegalArgumentException) {
+                    continue
+                }
+
+                if (capabilities == null || !capabilities.isFormatSupported(format)) {
+                    continue
+                }
+
+                val audioCapabilities = capabilities.audioCapabilities
+                    ?: throw IllegalArgumentException("${info.name} encoder has no audio capabilities")
+
+                val rates = audioCapabilities.supportedSampleRates
+                if (rates != null && rates.isNotEmpty()) {
+                    val ratesUnsigned = rates.toUIntArray()
+                    val default = DiscreteSampleRateInfo.toNearest(ratesUnsigned, tryDefault)!!
+
+                    return DiscreteSampleRateInfo(ratesUnsigned, default)
+                }
+
+                val rateRanges = audioCapabilities.supportedSampleRateRanges
+                if (rateRanges.isNotEmpty()) {
+                    val rateRangesUnsigned = rateRanges
+                        .map { it.lower.toUInt()..it.upper.toUInt() }
+                        .toTypedArray()
+                    val default = RangedSampleRateInfo.toNearest(rateRangesUnsigned, tryDefault)!!
+
+                    return RangedSampleRateInfo(rateRangesUnsigned, default)
+                }
+            }
+
+            throw IllegalArgumentException("No suitable encoder found for $format")
+        }
+    }
+}
+
+private fun absDiff(a: UInt, b: UInt): UInt = if (a > b) {
+    a - b
+} else {
+    b - a
 }
 
 class RangedSampleRateInfo(
-    val range: UIntRange,
+    val ranges: Array<UIntRange>,
     default: UInt,
-    presets: UIntArray,
-) : SampleRateInfo(default, presets) {
+) : SampleRateInfo(default, uintArrayOf(default)) {
     override fun validate(rate: UInt) {
-        if (rate !in range) {
-            throw IllegalArgumentException("Sample rate $rate is not in the range: " +
-                    "[${range.first}, ${range.last}]")
+        if (!ranges.any { rate in it }) {
+            throw IllegalArgumentException(
+                "Sample rate $rate is not in the ranges: ${ranges.contentToString()}")
         }
     }
 
-    /** Clamp [rate] to [range]. */
-    override fun toNearest(rate: UInt): UInt = rate.coerceIn(range)
+    /** Clamp [rate] to the nearest range in [ranges]. */
+    override fun toNearest(rate: UInt): UInt = toNearest(ranges, rate)!!
+
+    companion object {
+        fun toNearest(ranges: Array<UIntRange>, rate: UInt): UInt? = ranges
+            .asSequence()
+            .map { rate.coerceIn(it) }
+            .minByOrNull { absDiff(rate, it) }
+    }
 }
 
 class DiscreteSampleRateInfo(
@@ -50,6 +109,10 @@ class DiscreteSampleRateInfo(
     private val choices: UIntArray,
     default: UInt,
 ) : SampleRateInfo(default, choices) {
+    init {
+        require(choices.isNotEmpty()) { "List of choices cannot be empty" }
+    }
+
     override fun validate(rate: UInt) {
         if (rate !in choices) {
             throw IllegalArgumentException("Sample rate $rate is not supported: " +
@@ -58,11 +121,10 @@ class DiscreteSampleRateInfo(
     }
 
     /** Find closest sample rate in [choices] to [rate]. */
-    override fun toNearest(rate: UInt): UInt = choices.minBy {
-        if (it > rate) {
-            it - rate
-        } else {
-            rate - it
-        }
+    override fun toNearest(rate: UInt): UInt = toNearest(choices, rate)!!
+
+    companion object {
+        fun toNearest(choices: UIntArray, rate: UInt): UInt? =
+            choices.minByOrNull { absDiff(rate, it) }
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/format/WaveFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/WaveFormat.kt
@@ -1,20 +1,12 @@
-@file:OptIn(ExperimentalUnsignedTypes::class)
-
 package com.chiller3.bcr.format
 
 import android.media.MediaFormat
+import com.chiller3.bcr.extension.SAMPLE_RATE_HZ_MAX_COMPAT
+import com.chiller3.bcr.extension.SAMPLE_RATE_HZ_MIN_COMPAT
 import java.io.FileDescriptor
 
-object WaveFormat : Format() {
+data object WaveFormat : Format() {
     override val name: String = "WAV/PCM"
-    override val paramInfo: FormatParamInfo = NoParamInfo
-    override val sampleRateInfo: SampleRateInfo = RangedSampleRateInfo(
-        // WAV sample rate field is a 4-byte integer and there's nothing that theoretically prevents
-        // using an absurdly large sample rate.
-        1u..UInt.MAX_VALUE,
-        16_000u,
-        uintArrayOf(8_000u, 16_000u, 48_000u),
-    )
     // Should be "audio/vnd.wave" [1], but Android only recognizes "audio/x-wav" [2] for the
     // purpose of picking an appropriate file extension when creating a file via SAF.
     // [1] https://datatracker.ietf.org/doc/html/rfc2361
@@ -22,7 +14,14 @@ object WaveFormat : Format() {
     override val mimeTypeContainer: String = "audio/x-wav"
     override val mimeTypeAudio: String = "audio/x-wav"
     override val passthrough: Boolean = true
-    override val supported: Boolean = true
+    override val paramInfo: FormatParamInfo = NoParamInfo
+    override val sampleRateInfo: SampleRateInfo = RangedSampleRateInfo(
+        // WAV sample rate field is a 4-byte integer and there's nothing that theoretically prevents
+        // using an absurdly large sample rate. However, let's stick to a range that AudioRecord
+        // actually supports.
+        arrayOf(SAMPLE_RATE_HZ_MIN_COMPAT.toUInt()..SAMPLE_RATE_HZ_MAX_COMPAT.toUInt()),
+        16_000u,
+    )
 
     override fun updateMediaFormat(mediaFormat: MediaFormat, param: UInt) {
         // Not needed

--- a/app/src/main/java/com/chiller3/bcr/settings/OutputFormatBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/OutputFormatBottomSheetFragment.kt
@@ -44,10 +44,6 @@ class OutputFormatBottomSheetFragment : BottomSheetDialogFragment(),
         binding.reset.setOnClickListener(this)
 
         for (format in Format.all) {
-            if (!format.supported) {
-                continue
-            }
-
             addFormatChip(inflater, format)
         }
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -88,7 +88,7 @@
     
     <!-- Format sample rate dialog -->
     <string name="format_sample_rate_dialog_title">Özel örnekleme hızı</string>
-    <string name="format_sample_rate_dialog_message">Bu aralıkta bir örnekleme hızı değeri girin [%1$s, %2$s].</string>
+    <string name="format_sample_rate_dialog_message_range">[%1$s, %2$s]</string>
     
     <!-- Format parameter -->
     <string name="format_param_bitrate_bps">%s bps</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,7 +88,8 @@
 
     <!-- Format sample rate dialog -->
     <string name="format_sample_rate_dialog_title">Custom sample rate</string>
-    <string name="format_sample_rate_dialog_message">Enter a sample rate in the range [%1$s, %2$s].</string>
+    <string name="format_sample_rate_dialog_message_desc">Enter a sample rate within one of these ranges:</string>
+    <string name="format_sample_rate_dialog_message_range">[%1$s, %2$s]</string>
 
     <!-- Format parameter -->
     <string name="format_param_bitrate_bps">%s bps</string>


### PR DESCRIPTION
Some devices unfortunately disable common sample rates that are normally supported in AOSP's software encoders. This commit reworks all of BCR's MediaCodec-based formats to query for the list of supported sample rates instead of relying on a hardcoded list. If BCR's default sample rate for a format is not supported, the closest supported sample rate will be used. The same applies for Android upgrades that remove support for the sample rate previously chosen by the user.

These queries are fast enough to be unnoticeable on Pixel devices. Hopefully other OEMs don't make modifications that slow this down, like they do for so many other things.

Fixes: #507