### PR TITLE
CallMetadataCollector: getActiveSubscriptionInfo() can return null

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/output/CallMetadataCollector.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/CallMetadataCollector.kt
@@ -231,7 +231,7 @@ class CallMetadataCollector(
             val subscriptionInfo = subscriptionManager.getActiveSubscriptionInfo(subscriptionId)
 
             simCount = subscriptionManager.activeSubscriptionInfoCount
-            simSlot = subscriptionInfo.simSlotIndex + 1
+            simSlot = subscriptionInfo?.let { it.simSlotIndex + 1 }
         }
 
         val (callLogNumber, callLogName) = getCallLogDetails(parentDetails, allowBlockingCalls)


### PR DESCRIPTION
Issue: #513