### PR TITLE
Make recording calls from telecom-integrated apps optional

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -29,6 +29,7 @@ class Preferences(private val context: Context) {
         const val PREF_OUTPUT_FORMAT = "output_format"
         const val PREF_INHIBIT_BATT_OPT = "inhibit_batt_opt"
         const val PREF_WRITE_METADATA = "write_metadata"
+        const val PREF_RECORD_TELECOM_APPS = "record_telecom_apps"
         const val PREF_VERSION = "version"
 
         const val PREF_ADD_RULE = "add_rule"
@@ -309,6 +310,13 @@ class Preferences(private val context: Context) {
     var writeMetadata: Boolean
         get() = prefs.getBoolean(PREF_WRITE_METADATA, false)
         set(enabled) = prefs.edit { putBoolean(PREF_WRITE_METADATA, enabled) }
+
+    /**
+     * Whether to record calls from telecom-integrated apps.
+     */
+    var recordTelecomApps: Boolean
+        get() = prefs.getBoolean(PREF_RECORD_TELECOM_APPS, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_RECORD_TELECOM_APPS, enabled) }
 
     /**
      * Get a unique notification ID that increments on every call.

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -18,6 +18,8 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
     companion object {
         private val TAG = RecorderInCallService::class.java.simpleName
 
+        private const val PHONE_PACKAGE = "com.android.phone"
+
         private val ACTION_PAUSE = "${RecorderInCallService::class.java.canonicalName}.pause"
         private val ACTION_RESUME = "${RecorderInCallService::class.java.canonicalName}.resume"
         private val ACTION_RESTORE = "${RecorderInCallService::class.java.canonicalName}.restore"
@@ -234,6 +236,12 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         } else if (!Permissions.haveRequired(this)) {
             Log.v(TAG, "Required permissions have not been granted")
         } else if (!callsToRecorders.containsKey(call)) {
+            val callPackage = call.details.accountHandle.componentName.packageName
+            if (callPackage != PHONE_PACKAGE && !prefs.recordTelecomApps) {
+                Log.w(TAG, "Ignoring call associated with package: $callPackage")
+                return
+            }
+
             val recorder = try {
                 RecorderThread(this, this, call)
             } catch (e: Exception) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="pref_write_metadata_name">Write metadata file</string>
     <string name="pref_write_metadata_desc">Create a JSON file containing details about the call next to the audio file.</string>
 
+    <string name="pref_record_telecom_apps_name">Record telecom-integrated apps</string>
+    <string name="pref_record_telecom_apps_desc">Record calls from third-party apps that integrate with Android\'s telecom system. Recordings of these calls will likely contain only silence.</string>
+
     <!-- About "preference" -->
     <string name="pref_version_name">Version</string>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -41,6 +41,12 @@
             app:title="@string/pref_write_metadata_name"
             app:summary="@string/pref_write_metadata_desc"
             app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            app:key="record_telecom_apps"
+            app:title="@string/pref_record_telecom_apps_name"
+            app:summary="@string/pref_record_telecom_apps_desc"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
BCR records from the VOICE_CALL audio stream, which only works with plain old phone calls. Recording calls from telecom-integrated apps will likely only produce pure silence.

The recording of these calls is turned off by default to avoid producing useless recordings.

Issue: #513