### PR TITLE
Use android:usesNonSdkApi to access hidden/system APIs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -299,22 +299,6 @@ android.applicationVariants.all {
         }
     }
 
-    val configXml = tasks.register("configXml${capitalized}") {
-        inputs.property("variant.applicationId", variant.applicationId)
-
-        val outputFile = variantDir.map { it.file("config-${variant.applicationId}.xml") }
-        outputs.file(outputFile)
-
-        doLast {
-            outputFile.get().asFile.writeText("""
-                <?xml version="1.0" encoding="utf-8"?>
-                <config>
-                    <hidden-api-whitelisted-app package="${variant.applicationId}" />
-                </config>
-            """.trimIndent())
-        }
-    }
-
     val addonD = tasks.register("addonD${capitalized}") {
         inputs.property("variant.applicationId", variant.applicationId)
 
@@ -328,7 +312,6 @@ android.applicationVariants.all {
             "priv-app/${variant.applicationId}/${it.outputFile.name}"
         } + listOf(
             "etc/permissions/privapp-permissions-${variant.applicationId}.xml",
-            "etc/sysconfig/config-${variant.applicationId}.xml",
         )
 
         doLast {
@@ -374,9 +357,6 @@ android.applicationVariants.all {
         }
         from(permissionsXml.map { it.outputs }) {
             into("system/etc/permissions")
-        }
-        from(configXml.map { it.outputs }) {
-            into("system/etc/sysconfig")
         }
         from(variant.outputs.map { it.outputFile }) {
             into("system/priv-app/${variant.applicationId}")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,8 +25,16 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <!--
+        We use android:usesNonSdkApi to bypass Android's hidden API restrictions instead of creating
+        a sysconfig file with <hidden-api-whitelisted-app>. This is necessary because some custom
+        Android builds have a bug where the sysconfig file is only sometimes respected, leading to
+        intermittent app crashes.
+    -->
+    <!--suppress AndroidUnknownAttribute -->
     <application
         android:name=".RecorderApplication"
+        android:usesNonSdkApi="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
@@ -13,8 +13,8 @@ val AudioFormat.frameSizeInBytesCompat: Int
         2 * channelCount
     }
 
-// Static extension functions are currently not supported in Kotlin. Also, we install a sysconfig
-// file to allow access to these hidden fields.
+// Static extension functions are currently not supported in Kotlin. Also, we set usesNonSdkApi to
+// allow access to these hidden fields.
 
 @SuppressLint("SoonBlockedPrivateApi")
 val SAMPLE_RATE_HZ_MIN_COMPAT: Int =


### PR DESCRIPTION
Some custom Android builds seem to have a bug where the sysconfig file is not respected for some boots.

Fixes: #539
Fixes: #546