### PR TITLE
RecordRulesViewModel: Fix race condition when mutating rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add Arabic and Urdu translations ([PR #550 @TheDeathDragon])
 * Add Japanese translations ([PR #552 @musenq])
+* Fix race condition when adding record rules if BCR was unloaded from memory while a contact was being selected ([Issue #554], [PR #555 @chenxiaolong])
 
 ### Version 1.63
 
@@ -623,6 +624,7 @@ Non-user-facing changes:
 [Issue #513]: https://github.com/chenxiaolong/BCR/issues/513
 [Issue #539]: https://github.com/chenxiaolong/BCR/issues/539
 [Issue #546]: https://github.com/chenxiaolong/BCR/issues/546
+[Issue #554]: https://github.com/chenxiaolong/BCR/issues/554
 [PR #2 @chenxiaolong]: https://github.com/chenxiaolong/BCR/pull/2
 [PR #4 @EleoXDA]: https://github.com/chenxiaolong/BCR/pull/4
 [PR #7 @marat2509]: https://github.com/chenxiaolong/BCR/pull/7
@@ -866,3 +868,4 @@ Non-user-facing changes:
 [PR #549 @chenxiaolong]: https://github.com/chenxiaolong/BCR/pull/549
 [PR #550 @TheDeathDragon]: https://github.com/chenxiaolong/BCR/pull/550
 [PR #552 @musenq]: https://github.com/chenxiaolong/BCR/pull/552
+[PR #555 @chenxiaolong]: https://github.com/chenxiaolong/BCR/pull/555

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
@@ -34,7 +34,6 @@ class RecordRulesFragment : PreferenceFragmentCompat(), Preference.OnPreferenceC
     private lateinit var prefAddRule: Preference
 
     private var ruleOffset by Delegates.notNull<Int>()
-    private var rules = emptyList<DisplayedRecordRule>()
 
     private val requestContact =
         registerForActivityResult(ActivityResultContracts.PickContact()) { uri ->
@@ -155,8 +154,6 @@ class RecordRulesFragment : PreferenceFragmentCompat(), Preference.OnPreferenceC
             }
             categoryRules.addPreference(p)
         }
-
-        rules = newRules
     }
 
     override fun onPreferenceClick(preference: Preference): Boolean {


### PR DESCRIPTION
BCR can potentially be unloaded from memory when the user is in Android's contact picker activity. If this happens, when they return, the coroutines in `refreshRules()` and `addContactRule()` may execute at the same time. This does not cause crashes due to `MutableStateFlow`'s compare and set behavior, but does cause weird behavior, like the new contact rule being added to an empty list of rules.

Fixes: #554