### PR TITLE
root_preferences.xml: inhibit_batt_opt should not be persistent

### DIFF
--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -32,6 +32,7 @@
 
         <SwitchPreferenceCompat
             app:key="inhibit_batt_opt"
+            app:persistent="false"
             app:title="@string/pref_inhibit_batt_opt_name"
             app:summary="@string/pref_inhibit_batt_opt_desc"
             app:iconSpaceReserved="false" />


### PR DESCRIPTION
The persistent value is never read because the actual state is controlled by Android.