### PR TITLE
Delete addon.d script when installing as Magisk module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -376,6 +376,7 @@ android.applicationVariants.all {
         from(File(magiskDir, "boot_common.sh"))
         from(File(magiskDir, "post-fs-data.sh"))
         from(File(magiskDir, "service.sh"))
+        from(File(magiskDir, "customize.sh"))
 
         from(File(rootDir, "LICENSE"))
         from(File(rootDir, "README.md"))

--- a/app/magisk/customize.sh
+++ b/app/magisk/customize.sh
@@ -1,0 +1,2 @@
+#!/system/bin/sh
+[ -n "$MODPATH" ] && rm -r "$MODPATH/system/addon.d"

--- a/app/magisk/customize.sh
+++ b/app/magisk/customize.sh
@@ -1,2 +1,3 @@
 #!/system/bin/sh
+# Delete addon.d script when installing as Magisk module
 [ -n "$MODPATH" ] && rm -r "$MODPATH/system/addon.d"


### PR DESCRIPTION
LineageOS Updater falsely executes overlayed addon.d scripts for A/B partitioned devices during OTA.
It causes the Magisk modules' patched system files to be copied to the real system partition.
We need to delete our addon.d script when installing as Magisk module.