### PR TITLE
standalone: Log output to logcat

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/standalone/ClearPackageManagerCaches.kt
+++ b/app/src/main/java/com/chiller3/bcr/standalone/ClearPackageManagerCaches.kt
@@ -2,7 +2,9 @@
 
 package com.chiller3.bcr.standalone
 
+import android.util.Log
 import com.chiller3.bcr.BuildConfig
+import java.lang.invoke.MethodHandles
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.ExperimentalPathApi
@@ -12,15 +14,17 @@ import kotlin.io.path.readBytes
 import kotlin.io.path.walk
 import kotlin.system.exitProcess
 
+private val TAG = MethodHandles.lookup().lookupClass().simpleName
+
 private val PACKAGE_CACHE_DIR = Paths.get("/data/system/package_cache")
 
 private var dryRun = false
 
 private fun delete(path: Path) {
     if (dryRun) {
-        println("Would have deleted: $path")
+        Log.i(TAG, "Would have deleted: $path")
     } else {
-        println("Deleting: $path")
+        Log.i(TAG, "Deleting: $path")
         path.deleteIfExists()
     }
 }
@@ -68,7 +72,7 @@ private fun clearPackageManagerCache(appId: String): Boolean {
                 delete(path)
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.w(TAG, "Failed to delete $path", e)
             ret = false
         }
     }
@@ -88,8 +92,7 @@ fun main(args: Array<String>) {
     try {
         mainInternal()
     } catch (e: Exception) {
-        System.err.println("Failed to clear caches")
-        e.printStackTrace()
+        Log.e(TAG, "Failed to clear caches", e)
         exitProcess(1)
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/standalone/RemoveHardRestrictions.kt
+++ b/app/src/main/java/com/chiller3/bcr/standalone/RemoveHardRestrictions.kt
@@ -17,9 +17,13 @@ import android.os.IBinder
 import android.os.IInterface
 import android.os.Process
 import android.system.ErrnoException
+import android.util.Log
 import androidx.annotation.RequiresApi
 import com.chiller3.bcr.BuildConfig
+import java.lang.invoke.MethodHandles
 import kotlin.system.exitProcess
+
+private val TAG = MethodHandles.lookup().lookupClass().simpleName
 
 private const val GET_SERVICE_ATTEMPTS = 30
 private const val IS_USER_UNLOCKED_ATTEMPTS = 3600
@@ -310,11 +314,11 @@ private fun removeRestriction(packageName: String, permission: String, userId: I
 private fun waitForLogin(userId: Int) {
     val userManager = UserManagerProxy.instance
 
-    System.err.println("Waiting for user $userId to unlock the device")
+    Log.i(TAG, "Waiting for user $userId to unlock the device")
 
     for (attempt in 1..IS_USER_UNLOCKED_ATTEMPTS) {
         if (userManager.isUserUnlockingOrUnlocked(userId)) {
-            println("User $userId is unlocking/unlocked")
+            Log.i(TAG, "User $userId is unlocking/unlocked")
             return
         }
 
@@ -329,7 +333,7 @@ private fun waitForLogin(userId: Int) {
 
 private fun mainInternal() {
     if (Build.VERSION.SDK_INT == Build.VERSION_CODES.P) {
-        println("Android 9 does not have hard-restricted permissions")
+        Log.i(TAG, "Android 9 does not have hard-restricted permissions")
         return
     }
 
@@ -340,9 +344,9 @@ private fun mainInternal() {
     val suffix = "from ${BuildConfig.APPLICATION_ID} for ${Manifest.permission.READ_CALL_LOG}"
 
     if (changed) {
-        println("Successfully removed hard restriction $suffix")
+        Log.i(TAG, "Successfully removed hard restriction $suffix")
     } else {
-        println("Hard restriction already removed $suffix")
+        Log.i(TAG, "Hard restriction already removed $suffix")
     }
 }
 
@@ -350,8 +354,7 @@ fun main() {
     try {
         mainInternal()
     } catch (e: Exception) {
-        System.err.println("Failed to remove hard restrictions")
-        e.printStackTrace()
+        Log.e(TAG, "Failed to remove hard restrictions", e)
         exitProcess(1)
     }
 }


### PR DESCRIPTION
This makes it possible for these tools to be run from an init script without losing the output. There is no impact to the Magisk scripts since the logcat output is captured there anyway.