### PR TITLE
Switch DirectBootMigrationService to a background service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
@@ -62,8 +61,7 @@
 
         <service
             android:name=".DirectBootMigrationService"
-            android:exported="false"
-            android:foregroundServiceType="specialUse" />
+            android:exported="false" />
 
         <service
             android:name=".RecorderInCallService"

--- a/app/src/main/java/com/chiller3/bcr/DirectBootMigrationReceiver.kt
+++ b/app/src/main/java/com/chiller3/bcr/DirectBootMigrationReceiver.kt
@@ -10,6 +10,6 @@ class DirectBootMigrationReceiver : BroadcastReceiver() {
             return
         }
 
-        context.startForegroundService(Intent(context, DirectBootMigrationService::class.java))
+        context.startService(Intent(context, DirectBootMigrationService::class.java))
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/DirectBootMigrationService.kt
+++ b/app/src/main/java/com/chiller3/bcr/DirectBootMigrationService.kt
@@ -104,21 +104,12 @@ class DirectBootMigrationService : Service() {
 
     private fun startThread() {
         Log.i(TAG, "Starting direct boot file migration")
-
-        val notification = notifications.createPersistentNotification(
-            R.string.notification_direct_boot_migration_in_progress,
-            null,
-            emptyList(),
-        )
-        startForeground(prefs.nextNotificationId, notification)
-
         thread.start()
     }
 
     private fun tryStop() {
         if (!thread.isAlive) {
             Log.d(TAG, "Stopping service")
-            stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,6 @@
     <string name="notification_channel_failure_desc">Alerts for errors during call recording</string>
     <string name="notification_channel_success_name">Success alerts</string>
     <string name="notification_channel_success_desc">Alerts for successful call recordings</string>
-    <string name="notification_direct_boot_migration_in_progress">Migrating recordings</string>
     <string name="notification_direct_boot_migration_failed">Failed to migrate recordings</string>
     <string name="notification_direct_boot_migration_error">Some recordings saved before the device was initially unlocked could not be moved to the output directory.</string>
     <string name="notification_recording_initializing">Call recording initializing</string>


### PR DESCRIPTION
There seem to be two issues with the foreground service:

* Some Android builds seem to be broken and throw a ForegroundServiceDidNotStartInTimeException even though the service unconditionally calls startForeground() in onStartCommand(). The root cause of this is unknown. Perhaps these devices are exceptionally slow during boot?
* The persistent notification does not get dismissed when the file migration runs too quickly.

We may be able to work around the second issue by not setting the FOREGROUND_SERVICE_IMMEDIATE notification behavior flag, but given how fast the file migration is, let's just switch to a background service. We're unlikely to hit Android's limitations on background services.

Closes: #574
Closes: #576