### PR TITLE
Fix manually triggering direct boot file migration via debug settings

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -202,9 +202,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
             }
             prefMigrateDirectBoot -> {
                 val context = requireContext()
-                context.startForegroundService(
-                    Intent(context, DirectBootMigrationService::class.java)
-                )
+                context.startService(Intent(context, DirectBootMigrationService::class.java))
                 return true
             }
         }


### PR DESCRIPTION
SettingsFragment was still trying to start the service as a foreground service. This was overlooked in 17f6d19f65317b3f36b1a2329cca03a2f5cca22b.