### PR TITLE
Split pure silence warning notification to separate channel

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,8 @@
     <string name="notification_channel_failure_desc">Alerts for errors during call recording</string>
     <string name="notification_channel_success_name">Success alerts</string>
     <string name="notification_channel_success_desc">Alerts for successful call recordings</string>
+    <string name="notification_channel_silence_name">Pure silence warnings</string>
+    <string name="notification_channel_silence_desc">Warn if call recordings contained pure silence</string>
     <string name="notification_direct_boot_migration_failed">Failed to migrate recordings</string>
     <string name="notification_direct_boot_migration_error">Some recordings saved before the device was initially unlocked could not be moved to the output directory.</string>
     <string name="notification_recording_initializing">Call recording initializing</string>


### PR DESCRIPTION
The warning can sometimes be triggered when hanging up before the other party is able to answer, so allow the user to disable the notification if desired.

This commit also changes the recorder thread status reporting to be more explicit and type-safe. All user-facing error messages are now computed in the UI layers instead of the recorder thread.

Closes: #579