### PR TITLE
service.sh: Restore SELinux labels on DP data directory during boot

### DIFF
--- a/app/magisk/post-fs-data.sh
+++ b/app/magisk/post-fs-data.sh
@@ -7,7 +7,7 @@
 #
 # [1] https://cs.android.com/android/platform/superproject/+/android-13.0.0_r42:frameworks/base/services/core/java/com/android/server/pm/parsing/PackageCacher.java;l=139
 
-source "${0%/*}/boot_common.sh" /data/local/tmp/bcr_clear_package_manager_caches.log
+source "${0%/*}/boot_common.sh" /data/local/tmp/bcr_post-fs-data.log
 
 header Timestamps
 ls -ldZ "${cli_apk%/*}"

--- a/app/magisk/service.sh
+++ b/app/magisk/service.sh
@@ -5,10 +5,19 @@
 # to alter the flags. This command blocks for an arbitrary amount of time
 # because it needs to wait until the primary user unlocks the device.
 
-source "${0%/*}/boot_common.sh" /data/local/tmp/bcr_remove_hard_restrictions.log
+source "${0%/*}/boot_common.sh" /data/local/tmp/bcr_service.log
 
 header Remove hard restrictions
 run_cli_apk com.chiller3.bcr.standalone.RemoveHardRestrictionsKt
 
 header Package state
 dumpsys package "${app_id}"
+
+# Manually fix the SELinux-label for the device-protected data directory.
+# OxygenOS one OnePlus devices seems to initially create the directory with the
+# wrong label. For example, `u:object_r:app_data_file:s0:c79,c257,c512,c768`
+# instead of `u:object_r:privapp_data_file:s0:c512,c768`. This requires the
+# module to be flashed twice because we don't know what the expected label
+# should be until Android creates /data/data/<id>.
+header Fixing DP storage SELinux label
+restorecon -RDv /data/user_de/0/"${app_id}"


### PR DESCRIPTION
OxygenOS on OnePlus devices seems to create the `/data/user_de/0/<id>` directory with the wrong SELinux label initially. However, once the correct label is set, it persists just fine. Despite it persisting, we still need to run restorecon during boot instead of during installation because it requires PackageManager to already be aware of BCR.

Fixes: #582
Fixes: #591
Fixes: #598