### PR TITLE
Notifications: Fix isDeviceProtectedStorage() check

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -192,8 +192,8 @@ class Notifications(
 
         val file = outputFile.uri.toFile()
 
-        return file.relativeToOrNull(prefs.directBootInProgressDir) != null
-                && file.relativeToOrNull(prefs.directBootCompletedDir) != null
+        return file.startsWith(prefs.directBootInProgressDir)
+                || file.startsWith(prefs.directBootCompletedDir)
     }
 
     /**


### PR DESCRIPTION
This fixes success notifications not showing when using the default output directory. `relativeToOrNull()` can include `../` components, so it's not suitable for the job. The boolean operator was also incorrect.