### PR TITLE
Add support for specifying a minimum recording duration

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -29,6 +29,7 @@ class Preferences(initialContext: Context) {
         const val PREF_OUTPUT_DIR = "output_dir"
         const val PREF_FILENAME_TEMPLATE = "filename_template"
         const val PREF_OUTPUT_FORMAT = "output_format"
+        const val PREF_MIN_DURATION = "min_duration"
         const val PREF_INHIBIT_BATT_OPT = "inhibit_batt_opt"
         private const val PREF_WRITE_METADATA = "write_metadata"
         private const val PREF_RECORD_TELECOM_APPS = "record_telecom_apps"
@@ -383,6 +384,14 @@ class Preferences(initialContext: Context) {
             }
         }
     }
+
+    /**
+     * Minimum recording duration for it to be kept if the record rules would have allowed it to be
+     * kept in the first place.
+     */
+    var minDuration: Int
+        get() = prefs.getInt(PREF_MIN_DURATION, 0)
+        set(seconds) = prefs.edit { putInt(PREF_MIN_DURATION, seconds) }
 
     /**
      * Whether to write call metadata file.

--- a/app/src/main/java/com/chiller3/bcr/dialog/MinDurationDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/dialog/MinDurationDialogFragment.kt
@@ -1,0 +1,101 @@
+package com.chiller3.bcr.dialog
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.InputType
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.bcr.Preferences
+import com.chiller3.bcr.R
+import com.chiller3.bcr.databinding.DialogTextInputBinding
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class MinDurationDialogFragment : DialogFragment() {
+    companion object {
+        val TAG: String = MinDurationDialogFragment::class.java.simpleName
+
+        const val RESULT_SUCCESS = "success"
+    }
+
+    private lateinit var prefs: Preferences
+    private lateinit var binding: DialogTextInputBinding
+    private var minDuration: Int? = null
+    private var success: Boolean = false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = requireContext()
+        prefs = Preferences(context)
+        minDuration = prefs.minDuration
+
+        binding = DialogTextInputBinding.inflate(layoutInflater)
+
+        binding.message.setText(R.string.min_duration_dialog_message)
+
+        binding.text.inputType = InputType.TYPE_CLASS_NUMBER
+        binding.text.addTextChangedListener {
+            minDuration = if (it!!.isEmpty()) {
+                0
+            } else {
+                try {
+                    val seconds = it.toString().toInt()
+                    if (seconds >= 0) {
+                        seconds
+                    } else {
+                        null
+                    }
+                } catch (e: NumberFormatException) {
+                    null
+                }
+            }
+
+            refreshHelperText()
+            refreshOkButtonEnabledState()
+        }
+        if (savedInstanceState == null) {
+            binding.text.setText(minDuration?.toString())
+        }
+
+        refreshHelperText()
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.min_duration_dialog_title)
+            .setView(binding.root)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                prefs.minDuration = minDuration!!
+                success = true
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+            .apply {
+                setCanceledOnTouchOutside(false)
+            }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        refreshOkButtonEnabledState()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+
+    private fun refreshHelperText() {
+        val context = requireContext()
+
+        binding.textLayout.helperText = minDuration?.let {
+            context.resources.getQuantityString(R.plurals.min_duration_dialog_seconds, it, it)
+        }
+    }
+
+    private fun refreshOkButtonEnabledState() {
+        (dialog as AlertDialog?)?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
+            minDuration != null
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,13 @@
     <string name="pref_output_format_name">Output format</string>
     <string name="pref_output_format_desc">Select an encoding format for the recordings.</string>
 
+    <string name="pref_min_duration_name">Minimum recording duration</string>
+    <plurals name="pref_min_duration_desc">
+        <item quantity="one">Keep recordings at least %d second long.</item>
+        <item quantity="other">Keep recordings at least %d seconds long.</item>
+    </plurals>
+    <string name="pref_min_duration_desc_zero">Keep recordings of any length.</string>
+
     <string name="pref_inhibit_batt_opt_name">Disable battery optimization</string>
     <string name="pref_inhibit_batt_opt_desc">Reduces the chance of the app being killed by the system.</string>
 
@@ -113,6 +120,14 @@
     <!-- Format sample rate -->
     <string name="format_sample_rate">%s Hz</string>
 
+    <!-- Min duration dialog -->
+    <string name="min_duration_dialog_title">@string/pref_min_duration_name</string>
+    <string name="min_duration_dialog_message">Enter the minimum duration for a recording to be kept, excluding pauses and call holding. This can always be overridden during a call from the notification.</string>
+    <plurals name="min_duration_dialog_seconds">
+        <item quantity="one">%d second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
+
     <!-- Notifications -->
     <string name="notification_channel_persistent_name">Background services</string>
     <string name="notification_channel_persistent_desc">Persistent notification for background call recording</string>
@@ -132,6 +147,10 @@
     <string name="notification_recording_failed">Failed to record call</string>
     <string name="notification_recording_succeeded">Successfully recorded call</string>
     <string name="notification_message_delete_at_end">The recording will be deleted at the end of the call. Tap Restore to keep the recording.</string>
+    <plurals name="notification_message_delete_at_end_too_short">
+        <item quantity="one">The recording will be deleted at the end of the call if it is shorter than %d second. Tap Restore to keep the recording.</item>
+        <item quantity="other">The recording will be deleted at the end of the call if it is shorter than %d seconds. Tap Restore to keep the recording.</item>
+    </plurals>
     <string name="notification_internal_android_error">The recording failed in an internal Android component (%s). This device or firmware might not support call recording.</string>
     <string name="notification_pure_silence_error">The recording was discarded because the audio was completely silent. This device might not support recording calls associated with the \'%s\' app.</string>
     <string name="notification_action_open">Open</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -30,6 +30,12 @@
             app:summary="@string/pref_output_format_desc"
             app:iconSpaceReserved="false" />
 
+        <Preference
+            app:key="min_duration"
+            app:persistent="false"
+            app:title="@string/pref_min_duration_name"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             app:key="inhibit_batt_opt"
             app:persistent="false"


### PR DESCRIPTION
If the recording isn't long enough, it will be discarded at the end of the call. The duration is computed based on the recording duration (number of encoded frames), not the call duration, so it excludes regions where the user explicitly paused the recording and regions where the call was placed on hold.

Similar to the record rules, this can be overridden during the call from BCR's notification.

Fixes: #411
Fixes: #604