### PR TITLE
Add support for using contact groups in record rules

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,10 @@
         </activity>
 
         <activity
+            android:name=".rule.PickContactGroupActivity"
+            android:exported="false" />
+
+        <activity
             android:name=".rule.RecordRulesActivity"
             android:exported="false" />
     </application>

--- a/app/src/main/java/com/chiller3/bcr/Contact.kt
+++ b/app/src/main/java/com/chiller3/bcr/Contact.kt
@@ -3,19 +3,47 @@ package com.chiller3.bcr
 import android.Manifest
 import android.content.Context
 import android.net.Uri
+import android.os.Parcelable
 import android.provider.ContactsContract
 import androidx.annotation.RequiresPermission
+import androidx.core.database.getLongOrNull
+import androidx.core.database.getStringOrNull
 import com.chiller3.bcr.output.PhoneNumber
+import kotlinx.parcelize.Parcelize
 
 private val PROJECTION = arrayOf(
     ContactsContract.PhoneLookup.LOOKUP_KEY,
     ContactsContract.PhoneLookup.DISPLAY_NAME,
 )
 
+private val PROJECTION_GROUP_MEMBERSHIP = arrayOf(
+    ContactsContract.CommonDataKinds.GroupMembership.GROUP_ROW_ID,
+    ContactsContract.CommonDataKinds.GroupMembership.GROUP_SOURCE_ID,
+)
+
+private val CONTACT_GROUP_PROJECTION = arrayOf(
+    ContactsContract.Groups._ID,
+    ContactsContract.Groups.SOURCE_ID,
+    ContactsContract.Groups.TITLE,
+)
+
 data class ContactInfo(
     val lookupKey: String,
     val displayName: String,
 )
+
+sealed interface GroupLookup {
+    data class RowId(val id: Long): GroupLookup
+
+    data class SourceId(val id: String): GroupLookup
+}
+
+@Parcelize
+data class ContactGroupInfo(
+    val rowId: Long,
+    val sourceId: String,
+    val title: String,
+) : Parcelable
 
 @RequiresPermission(Manifest.permission.READ_CONTACTS)
 fun findContactsByPhoneNumber(context: Context, number: PhoneNumber): Iterator<ContactInfo> {
@@ -35,7 +63,7 @@ fun findContactsByPhoneNumber(context: Context, number: PhoneNumber): Iterator<C
 }
 
 @RequiresPermission(Manifest.permission.READ_CONTACTS)
-fun findContactByLookupKey(context: Context, lookupKey: String): ContactInfo? {
+fun getContactByLookupKey(context: Context, lookupKey: String): ContactInfo? {
     val uri = ContactsContract.Contacts.CONTENT_LOOKUP_URI.buildUpon()
         .appendPath(lookupKey)
         .build()
@@ -53,6 +81,107 @@ fun findContactsByUri(context: Context, uri: Uri) = iterator {
 
             while (cursor.moveToNext()) {
                 yield(ContactInfo(cursor.getString(indexLookupKey), cursor.getString(indexName)))
+            }
+        }
+    }
+}
+
+@RequiresPermission(Manifest.permission.READ_CONTACTS)
+fun getContactGroupMemberships(context: Context, lookupKey: String) = iterator {
+    val selection = buildString {
+        append(ContactsContract.CommonDataKinds.GroupMembership.LOOKUP_KEY)
+        append(" = ? AND ")
+        append(ContactsContract.CommonDataKinds.GroupMembership.MIMETYPE)
+        append(" = ?")
+    }
+    val selectionArgs = arrayOf(
+        lookupKey,
+        ContactsContract.CommonDataKinds.GroupMembership.CONTENT_ITEM_TYPE,
+    )
+
+    context.contentResolver.query(
+        ContactsContract.Data.CONTENT_URI,
+        PROJECTION_GROUP_MEMBERSHIP,
+        selection,
+        selectionArgs,
+        null,
+    )?.let { cursor ->
+        val indexRowId = cursor.getColumnIndexOrThrow(
+            ContactsContract.CommonDataKinds.GroupMembership.GROUP_ROW_ID)
+        val indexSourceId = cursor.getColumnIndexOrThrow(
+            ContactsContract.CommonDataKinds.GroupMembership.GROUP_SOURCE_ID)
+
+        if (cursor.moveToFirst()) {
+            cursor.getLongOrNull(indexRowId)?.let {
+                yield(GroupLookup.RowId(it))
+            }
+            cursor.getStringOrNull(indexSourceId)?.let {
+                yield(GroupLookup.SourceId(it))
+            }
+
+            while (cursor.moveToNext()) {
+                cursor.getLongOrNull(indexRowId)?.let {
+                    yield(GroupLookup.RowId(it))
+                }
+                cursor.getStringOrNull(indexSourceId)?.let {
+                    yield(GroupLookup.SourceId(it))
+                }
+            }
+        }
+    }
+}
+
+@RequiresPermission(Manifest.permission.READ_CONTACTS)
+fun getContactGroupById(context: Context, id: GroupLookup): ContactGroupInfo? {
+    var selectionArgs: Array<String>? = null
+    val selection = buildString {
+        when (id) {
+            is GroupLookup.RowId -> {
+                append(ContactsContract.Groups._ID)
+                append(" = ")
+                append(id.id)
+            }
+            is GroupLookup.SourceId -> {
+                append(ContactsContract.Groups.SOURCE_ID)
+                append(" = ?")
+
+                selectionArgs = arrayOf(id.id)
+            }
+        }
+    }
+
+    return findContactGroups(context, selection, selectionArgs).asSequence().firstOrNull()
+}
+
+fun findContactGroups(
+    context: Context,
+    selection: String? = null,
+    selectionArgs: Array<String>? = null,
+) = iterator {
+    context.contentResolver.query(
+        ContactsContract.Groups.CONTENT_URI,
+        CONTACT_GROUP_PROJECTION,
+        selection,
+        selectionArgs,
+        null,
+    )?.use { cursor ->
+        val indexRowId = cursor.getColumnIndexOrThrow(ContactsContract.Groups._ID)
+        val indexSourceId = cursor.getColumnIndexOrThrow(ContactsContract.Groups.SOURCE_ID)
+        val indexTitle = cursor.getColumnIndexOrThrow(ContactsContract.Groups.TITLE)
+
+        if (cursor.moveToFirst()) {
+            yield(ContactGroupInfo(
+                cursor.getLong(indexRowId),
+                cursor.getString(indexSourceId),
+                cursor.getString(indexTitle),
+            ))
+
+            while (cursor.moveToNext()) {
+                yield(ContactGroupInfo(
+                    cursor.getLong(indexRowId),
+                    cursor.getString(indexSourceId),
+                    cursor.getString(indexTitle),
+                ))
             }
         }
     }

--- a/app/src/main/java/com/chiller3/bcr/PreferenceBaseActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/PreferenceBaseActivity.kt
@@ -1,0 +1,65 @@
+package com.chiller3.bcr
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.ViewGroup
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.fragment.app.Fragment
+import com.chiller3.bcr.databinding.SettingsActivityBinding
+
+abstract class PreferenceBaseActivity : AppCompatActivity() {
+    protected abstract val titleResId: Int
+
+    protected abstract val showUpButton: Boolean
+
+    protected abstract fun createFragment(): Fragment
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+
+        val binding = SettingsActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.settings, createFragment())
+                .commit()
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.toolbar) { v, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = insets.left
+                topMargin = insets.top
+                rightMargin = insets.right
+            }
+
+            WindowInsetsCompat.CONSUMED
+        }
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar!!.setDisplayHomeAsUpEnabled(showUpButton)
+
+        setTitle(titleResId)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressedDispatcher.onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/PreferenceBaseFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/PreferenceBaseFragment.kt
@@ -1,0 +1,43 @@
+package com.chiller3.bcr
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.preference.PreferenceFragmentCompat
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class PreferenceBaseFragment : PreferenceFragmentCompat() {
+    override fun onCreateRecyclerView(
+        inflater: LayoutInflater,
+        parent: ViewGroup,
+        savedInstanceState: Bundle?
+    ): RecyclerView {
+        val view = super.onCreateRecyclerView(inflater, parent, savedInstanceState)
+
+        view.clipToPadding = false
+
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            // This is a little bit ugly in landscape mode because the divider lines for categories
+            // extend into the inset area. However, it's worth applying the left/right padding here
+            // anyway because it allows the inset area to be used for scrolling instead of just
+            // being a useless dead zone.
+            v.updatePadding(
+                bottom = insets.bottom,
+                left = insets.left,
+                right = insets.right,
+            )
+
+            WindowInsetsCompat.CONSUMED
+        }
+
+        return view
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -38,8 +38,8 @@ class Preferences(initialContext: Context) {
         private const val PREF_FORCE_DIRECT_BOOT = "force_direct_boot"
         const val PREF_MIGRATE_DIRECT_BOOT = "migrate_direct_boot"
 
-        const val PREF_ADD_RULE = "add_rule"
-        const val PREF_RULE_PREFIX = "rule_"
+        const val PREF_ADD_CONTACT_RULE = "add_contact_rule"
+        const val PREF_ADD_CONTACT_GROUP_RULE = "add_contact_group_rule"
 
         // Not associated with a UI preference
         private const val PREF_DEBUG_MODE = "debug_mode"

--- a/app/src/main/java/com/chiller3/bcr/rule/PickContactGroup.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/PickContactGroup.kt
@@ -1,0 +1,25 @@
+package com.chiller3.bcr.rule
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.IntentCompat
+import com.chiller3.bcr.ContactGroupInfo
+
+/** Launch our own picker for contact groups. There is no standard Android component for this. */
+class PickContactGroup : ActivityResultContract<Void?, ContactGroupInfo?>() {
+    override fun createIntent(context: Context, input: Void?): Intent {
+        return Intent(context, PickContactGroupActivity::class.java)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): ContactGroupInfo? {
+        return intent.takeIf { resultCode == Activity.RESULT_OK }?.let {
+            IntentCompat.getParcelableExtra(
+                it,
+                PickContactGroupActivity.RESULT_CONTACT_GROUP,
+                ContactGroupInfo::class.java,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupActivity.kt
@@ -1,0 +1,17 @@
+package com.chiller3.bcr.rule
+
+import androidx.fragment.app.Fragment
+import com.chiller3.bcr.PreferenceBaseActivity
+import com.chiller3.bcr.R
+
+class PickContactGroupActivity : PreferenceBaseActivity() {
+    override val titleResId: Int = R.string.pick_contact_group_title
+
+    override val showUpButton: Boolean = true
+
+    override fun createFragment(): Fragment = PickContactGroupFragment()
+
+    companion object {
+        const val RESULT_CONTACT_GROUP = "contact_group"
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupFragment.kt
@@ -1,0 +1,75 @@
+package com.chiller3.bcr.rule
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.preference.Preference
+import androidx.preference.get
+import androidx.preference.size
+import com.chiller3.bcr.ContactGroupInfo
+import com.chiller3.bcr.PreferenceBaseFragment
+import com.chiller3.bcr.R
+import kotlinx.coroutines.launch
+
+class PickContactGroupFragment : PreferenceBaseFragment(), Preference.OnPreferenceClickListener {
+    private val viewModel: PickContactGroupViewModel by viewModels()
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.record_rules_preferences, rootKey)
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.groups.collect {
+                    updateGroups(it)
+                }
+            }
+        }
+    }
+
+    private fun updateGroups(newGroups: List<ContactGroupInfo>) {
+        val context = requireContext()
+
+        for (i in (0 until preferenceScreen.size).reversed()) {
+            val p = preferenceScreen[i]
+            preferenceScreen.removePreference(p)
+        }
+
+        for ((i, group) in newGroups.withIndex()) {
+            val p = Preference(context).apply {
+                key = PREF_GROUP_PREFIX + i
+                isPersistent = false
+                title = group.title
+                isIconSpaceReserved = false
+                onPreferenceClickListener = this@PickContactGroupFragment
+            }
+            preferenceScreen.addPreference(p)
+        }
+    }
+
+    override fun onPreferenceClick(preference: Preference): Boolean {
+        when {
+            preference.key.startsWith(PREF_GROUP_PREFIX) -> {
+                val index = preference.key.substring(PREF_GROUP_PREFIX.length).toInt()
+                val activity = requireActivity()
+
+                activity.setResult(Activity.RESULT_OK, Intent().putExtra(
+                    PickContactGroupActivity.RESULT_CONTACT_GROUP,
+                    viewModel.groups.value[index],
+                ))
+                activity.finish()
+
+                return true
+            }
+        }
+
+        return false
+    }
+
+    companion object {
+        private const val PREF_GROUP_PREFIX = "group_"
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupViewModel.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupViewModel.kt
@@ -1,0 +1,53 @@
+package com.chiller3.bcr.rule
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.chiller3.bcr.ContactGroupInfo
+import com.chiller3.bcr.findContactGroups
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class PickContactGroupViewModel(application: Application) : AndroidViewModel(application) {
+    private val _groups = MutableStateFlow<List<ContactGroupInfo>>(emptyList())
+    val groups: StateFlow<List<ContactGroupInfo>> = _groups
+
+    init {
+        refreshGroups()
+    }
+
+    private fun refreshGroups() {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                val groups = try {
+                    findContactGroups(getApplication())
+                        .asSequence()
+                        .sortedWith { o1, o2 ->
+                            compareValuesBy(
+                                o1,
+                                o2,
+                                { it.title },
+                                { it.rowId },
+                                { it.sourceId },
+                            )
+                        }
+                        .toList()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to list all contact groups", e)
+                    return@withContext
+                }
+
+                _groups.update { groups }
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = PickContactGroupViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesActivity.kt
@@ -1,60 +1,13 @@
 package com.chiller3.bcr.rule
 
-import android.os.Bundle
-import android.view.MenuItem
-import android.view.ViewGroup
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
+import androidx.fragment.app.Fragment
+import com.chiller3.bcr.PreferenceBaseActivity
 import com.chiller3.bcr.R
-import com.chiller3.bcr.databinding.SettingsActivityBinding
 
-class RecordRulesActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
-        super.onCreate(savedInstanceState)
+class RecordRulesActivity : PreferenceBaseActivity() {
+    override val titleResId: Int = R.string.pref_record_rules_name
 
-        val binding = SettingsActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+    override val showUpButton: Boolean = true
 
-        if (savedInstanceState == null) {
-            supportFragmentManager
-                .beginTransaction()
-                .replace(R.id.settings, RecordRulesFragment())
-                .commit()
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.toolbar) { v, windowInsets ->
-            val insets = windowInsets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                        or WindowInsetsCompat.Type.displayCutout()
-            )
-
-            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                leftMargin = insets.left
-                topMargin = insets.top
-                rightMargin = insets.right
-            }
-
-            WindowInsetsCompat.CONSUMED
-        }
-
-        setSupportActionBar(binding.toolbar)
-        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-
-        setTitle(R.string.pref_record_rules_name)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                onBackPressedDispatcher.onBackPressed()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
+    override fun createFragment(): Fragment = RecordRulesFragment()
 }

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsActivity.kt
@@ -1,47 +1,13 @@
 package com.chiller3.bcr.settings
 
-import android.os.Bundle
-import android.view.ViewGroup
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
+import androidx.fragment.app.Fragment
+import com.chiller3.bcr.PreferenceBaseActivity
 import com.chiller3.bcr.R
-import com.chiller3.bcr.databinding.SettingsActivityBinding
 
-class SettingsActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
-        super.onCreate(savedInstanceState)
+class SettingsActivity : PreferenceBaseActivity() {
+    override val titleResId: Int = R.string.app_name_full
 
-        val binding = SettingsActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+    override val showUpButton: Boolean = false
 
-        if (savedInstanceState == null) {
-            supportFragmentManager
-                    .beginTransaction()
-                    .replace(R.id.settings, SettingsFragment())
-                    .commit()
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.toolbar) { v, windowInsets ->
-            val insets = windowInsets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                        or WindowInsetsCompat.Type.displayCutout()
-            )
-
-            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                leftMargin = insets.left
-                topMargin = insets.top
-                rightMargin = insets.right
-            }
-
-            WindowInsetsCompat.CONSUMED
-        }
-
-        setSupportActionBar(binding.toolbar)
-
-        setTitle(R.string.app_name_full)
-    }
+    override fun createFragment(): Fragment = SettingsFragment()
 }

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -5,20 +5,14 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
-import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
-import androidx.recyclerview.widget.RecyclerView
 import com.chiller3.bcr.BuildConfig
 import com.chiller3.bcr.DirectBootMigrationService
 import com.chiller3.bcr.Permissions
+import com.chiller3.bcr.PreferenceBaseFragment
 import com.chiller3.bcr.Preferences
 import com.chiller3.bcr.R
 import com.chiller3.bcr.dialog.MinDurationDialogFragment
@@ -32,7 +26,7 @@ import com.chiller3.bcr.view.LongClickablePreference
 import com.chiller3.bcr.view.OnPreferenceLongClickListener
 import com.google.android.material.snackbar.Snackbar
 
-class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChangeListener,
+class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChangeListener,
     Preference.OnPreferenceClickListener, OnPreferenceLongClickListener,
     SharedPreferences.OnSharedPreferenceChangeListener {
     private lateinit var prefs: Preferences
@@ -59,37 +53,6 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             refreshInhibitBatteryOptState()
         }
-
-    override fun onCreateRecyclerView(
-        inflater: LayoutInflater,
-        parent: ViewGroup,
-        savedInstanceState: Bundle?
-    ): RecyclerView {
-        val view = super.onCreateRecyclerView(inflater, parent, savedInstanceState)
-
-        view.clipToPadding = false
-
-        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
-            val insets = windowInsets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                        or WindowInsetsCompat.Type.displayCutout()
-            )
-
-            // This is a little bit ugly in landscape mode because the divider lines for categories
-            // extend into the inset area. However, it's worth applying the left/right padding here
-            // anyway because it allows the inset area to be used for scrolling instead of just
-            // being a useless dead zone.
-            v.updatePadding(
-                bottom = insets.bottom,
-                left = insets.left,
-                right = insets.right,
-            )
-
-            WindowInsetsCompat.CONSUMED
-        }
-
-        return view
-    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         val context = requireContext()

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -13,8 +13,7 @@
     <string name="pref_inhibit_batt_opt_name"> تعطيل تحسين البطارية</string>
     <string name="pref_version_name">الاصدار</string>
     <string name="pref_header_rules">الارقام المراد تسجيل مكالماتها</string>
-    <string name="pref_add_rule_name">اضافه ارقام</string>
-    <string name="pref_add_rule_desc">اضافه الرقم لقائمه التسجيل</string>
+    <string name="pref_add_contact_rule_desc">اضافه الرقم لقائمه التسجيل</string>
     <string name="record_rules_rule_added">اضافه الرقم للتسجيل ، اضغط مطولا للحذف</string>
     <string name="record_rules_rule_exists">الرقم موجود سابقا</string>
     <string name="record_rules_info">عند تشغيل هذه الميزة، يتم تسجيل المكالمة تلقائيًا بشكل افتراضي ويمكن حذفها يدويًا من الإشعار. عند إيقاف تشغيل هذه الخاصية ، سيتم حذف التسجيل في نهاية المكالمة ما لم يتم الاحتفاظ به باستخدام زر الاستعادة في الإشعار.</string>
@@ -22,7 +21,7 @@
     <string name="record_rule_type_all_other_calls_name">جميع المكالمات الاخرئ</string>
     <string name="record_rule_type_unknown_calls_name">ارقام غير معروفه</string>
     <string name="record_rule_type_contact_name">الاسم: %s</string>
-    <string name="record_rule_type_contact_desc">ضغطه متواصله لحذف القيد</string>
+    <string name="record_rule_removable_desc">ضغطه متواصله لحذف القيد</string>
     <string name="output_dir_bottom_sheet_change_dir">تغيير المجلد</string>
     <string name="output_dir_bottom_sheet_filename_template">اسم القالب</string>
     <string name="output_dir_bottom_sheet_edit_template">تعديل القالب</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,9 +24,8 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Version</string>
 
-    <!-- Record rules bottom sheet -->
-    <string name="pref_add_rule_name">Füge eine Regel hinzu</string>
-    <string name="pref_add_rule_desc">Füge eine automatische Aufnahmeregel für einen Kontakt hinzu.</string>
+    <!-- Record rules activity -->
+    <string name="pref_add_contact_rule_desc">Füge eine automatische Aufnahmeregel für einen Kontakt hinzu.</string>
     <string name="record_rules_rule_added">Neue Regel hinzugefügt. Lange gedrückt halten, um sie zu löschen.</string>
     <string name="record_rules_rule_exists">Regel existiert bereits.</string>
     <string name="record_rule_type_all_other_calls_name">Alle anderen Anrufe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,10 +41,9 @@
     <string name="pref_migrate_direct_boot_name">Déplacer les enregistrements du démarrage direct</string>
     <string name="pref_migrate_direct_boot_desc">Déplacer les enregistrements réalisés avant le premier déverrouillage. Cela devrait se produire normalement après le premier déverrouillage.</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Règles</string>
-    <string name="pref_add_rule_name">Ajouter une règle</string>
-    <string name="pref_add_rule_desc">Ajouter une règle d\auto-enregistrement pour un contact.</string>
+    <string name="pref_add_contact_rule_desc">Ajouter une règle d\auto-enregistrement pour un contact.</string>
     <string name="record_rules_rule_added">Règle ajoutée. Maintenir appuyé pour la supprimer.</string>
     <string name="record_rules_rule_exists">Règle déjà existante.</string>
     <string name="record_rules_info">Quand une règle est active, l\'appel est automatiquement enregistré et peut être supprimé manuellement via la notification. Quand une règle est inactive, l\'enregistrement sera supprimé automatiquement à la fin de l\'appel et peut être restauré manuellement via la notification.</string>
@@ -55,7 +54,7 @@
     <string name="record_rule_type_unknown_calls_name">Appels inconnus</string>
     <string name="record_rule_type_unknown_calls_desc">Appels ne correspondant à aucun contact.</string>
     <string name="record_rule_type_contact_name">Contact: %s</string>
-    <string name="record_rule_type_contact_desc">Maintenir appuyé pour supprimer la règle.</string>
+    <string name="record_rule_removable_desc">Maintenir appuyé pour supprimer la règle.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Changer le dossier</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -27,10 +27,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">वर्जन:</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">नियम</string>
-    <string name="pref_add_rule_name">नियम जोड़ें</string>
-    <string name="pref_add_rule_desc">किसी संपर्क के लिए ऑटो-रिकॉर्ड नियम जोड़ें।</string>
+    <string name="pref_add_contact_rule_desc">किसी संपर्क के लिए ऑटो-रिकॉर्ड नियम जोड़ें।</string>
     <string name="record_rules_rule_added">नया नियम जोड़ा गया। नियम को हटाने के लिए उसे देर तक दबाएँ।</string>
     <string name="record_rules_rule_exists">नियम पहले से मौजूद है।</string>
     <string name="record_rules_info">जब कोई नियम चालू होता है, तो कॉल डिफ़ॉल्ट रूप से स्वचालित रूप से रिकॉर्ड हो जाती है और अधिसूचना से मैन्युअल रूप से हटाया जा सकता है। जब कोई नियम बंद कर दिया जाता है, तो कॉल के अंत में रिकॉर्डिंग हटा दी जाएगी जब तक कि इसे अधिसूचना में पुनर्स्थापना बटन का उपयोग करके संरक्षित नहीं किया जाता है।</string>
@@ -41,7 +40,7 @@
     <string name="record_rule_type_unknown_calls_name">अज्ञात कॉल</string>
     <string name="record_rule_type_unknown_calls_desc">ऐसी कॉलें जो किसी भी संपर्क से मेल नहीं खातीं।</string>
     <string name="record_rule_type_contact_name">संपर्क: %s</string>
-    <string name="record_rule_type_contact_desc">नियम हटाने के लिए देर तक दबाएँ।</string>
+    <string name="record_rule_removable_desc">नियम हटाने के लिए देर तक दबाएँ।</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">निर्देशिका बदलें</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,10 +27,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Versione</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Regole</string>
-    <string name="pref_add_rule_name">Aggiungi regola</string>
-    <string name="pref_add_rule_desc">Aggiungi una regola automatica per un contatto.</string>
+    <string name="pref_add_contact_rule_desc">Aggiungi una regola automatica per un contatto.</string>
     <string name="record_rules_rule_added">Nuova regola aggiunta. Tieni premuto per cancellarla.</string>
     <string name="record_rules_rule_exists">La regola già esiste.</string>
     <string name="record_rules_info">Quando una regola è attiva, la chiamata verrà registrata automaticamente e potrà essere cancellata dalla notifica. Quando una regola non è attiva, la registrazione verrà cancellata alla fine della chiamata a meno che non premi Ripristina nella notifica.</string>
@@ -41,7 +40,7 @@
     <string name="record_rule_type_unknown_calls_name">Sconosciuto</string>
     <string name="record_rule_type_unknown_calls_desc">Chiamate che non rientrano in nessun contatto.</string>
     <string name="record_rule_type_contact_name">Contatto: %s</string>
-    <string name="record_rule_type_contact_desc">Tieni premuto per rimuovere la regola.</string>
+    <string name="record_rule_removable_desc">Tieni premuto per rimuovere la regola.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Cambia cartella</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -27,10 +27,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">מספר גרסה</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">כללים</string>
-    <string name="pref_add_rule_name">הוסף כלל</string>
-    <string name="pref_add_rule_desc">הוסף כלל הקלטה אוטומטית עבור איש קשר.</string>
+    <string name="pref_add_contact_rule_desc">הוסף כלל הקלטה אוטומטית עבור איש קשר.</string>
     <string name="record_rules_rule_added">כלל חדש נוסף. לחץ לחיצה ארוכה על הכלל כדי למחוק אותו.</string>
     <string name="record_rules_rule_exists">הכלל כבר קיים.</string>
     <string name="record_rules_info">כאשר כלל מופעל, השיחה מוקלטת באופן אוטומטי כברירת מחדל וניתן למחוק אותה באופן ידני מההודעה. כאשר כלל מבוטל, ההקלטה תימחק בסוף שיחה, אלא אם כן היא נשמרת באמצעות לחצן שחזר בהודעה.</string>
@@ -41,7 +40,7 @@
     <string name="record_rule_type_unknown_calls_name">שיחות לא מזוהות</string>
     <string name="record_rule_type_unknown_calls_desc">שיחות שאינן מאנשי הקשר.</string>
     <string name="record_rule_type_contact_name">איש קשר: %s</string>
-    <string name="record_rule_type_contact_desc">לחץ לחיצה ארוכה כדי להסיר כלל.</string>
+    <string name="record_rule_removable_desc">לחץ לחיצה ארוכה כדי להסיר כלל.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">שינוי תיקיה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -57,8 +57,7 @@
     <string name="pref_record_telecom_apps_desc">Android の通信システムと統合されているサードパーティ製アプリからの通話を録音します。 これらの通話の録音は、無音となってしまう可能性があります。</string>
     <string name="pref_version_name">バージョン</string>
     <string name="pref_header_rules">ルール</string>
-    <string name="pref_add_rule_name">ルールの追加</string>
-    <string name="pref_add_rule_desc">連絡先による自動録音ルールを追加します。</string>
+    <string name="pref_add_contact_rule_desc">連絡先による自動録音ルールを追加します。</string>
     <string name="record_rules_rule_added">新しいルールを追加しました。 ルールを長押しして削除します。</string>
     <string name="record_rules_rule_exists">ルールはすでに存在します。</string>
     <string name="record_rules_info">ルールがオンになっている場合、通話はデフォルトで自動的に録音され、通知から手動で削除できます。 ルールがオフになっている場合、通知の [復元] ボタンを使用して録音を保存しない限り、通話の終了時に録音は削除されます。</string>
@@ -69,7 +68,7 @@
     <string name="record_rule_type_unknown_calls_name">不明な通話</string>
     <string name="record_rule_type_unknown_calls_desc">どの連絡先とも一致しない通話。</string>
     <string name="record_rule_type_contact_name">連絡先: %s</string>
-    <string name="record_rule_type_contact_desc">長押ししてルールを削除します。</string>
+    <string name="record_rule_removable_desc">長押ししてルールを削除します。</string>
     <string name="output_dir_bottom_sheet_change_dir">ディレクトリを変更する</string>
     <string name="output_dir_bottom_sheet_filename_template">ファイル名のテンプレート</string>
     <string name="output_dir_bottom_sheet_edit_template">テンプレートの編集</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -30,10 +30,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Wersja</string>
     
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Reguły</string>
-    <string name="pref_add_rule_name">Dodaj regułę</string>
-    <string name="pref_add_rule_desc">Dodaj regułę automatycznego rejestrowania dla kontaktu.</string>
+    <string name="pref_add_contact_rule_desc">Dodaj regułę automatycznego rejestrowania dla kontaktu.</string>
     <string name="record_rules_rule_added">Dodano nową regułę. Naciśnij i przytrzymaj regułę, aby ją usunąć.</string>
     <string name="record_rules_rule_exists">Reguła już istnieje.</string>
     <string name="record_rules_info">Gdy reguła jest włączona, połączenie jest domyślnie automatycznie nagrywane i można je ręcznie usunąć z powiadomienia. Gdy reguła jest wyłączona, nagranie zostanie usunięte po zakończeniu połączenia, chyba że zostanie zachowane za pomocą przycisku Przywróć w powiadomieniu.</string>
@@ -44,7 +43,7 @@
     <string name="record_rule_type_unknown_calls_name">Nieznane połączenia</string>
     <string name="record_rule_type_unknown_calls_desc">Połączenia, które nie pasują do żadnego kontaktu.</string>
     <string name="record_rule_type_contact_name">Kontakt: %s</string>
-    <string name="record_rule_type_contact_desc">Naciśnij i przytrzymaj, aby usunąć regułę.</string>
+    <string name="record_rule_removable_desc">Naciśnij i przytrzymaj, aby usunąć regułę.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Zmień katalog</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -27,10 +27,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Versão</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Regras</string>
-    <string name="pref_add_rule_name">Adicionar Regra</string>
-    <string name="pref_add_rule_desc">Adicione uma regra de auto-gravação para um contacto.</string>
+    <string name="pref_add_contact_rule_desc">Adicione uma regra de auto-gravação para um contacto.</string>
     <string name="record_rules_rule_added">Adicionou nova regra. Pressione longamente para eliminar.</string>
     <string name="record_rules_rule_exists">Regra já existe.</string>
     <string name="record_rules_info">Quando uma regra está ativada, a chamada é gravada automaticamente por padrão e pode ser eliminada manualmente a partir da notificação. Quando uma regra está desativada, a gravação será eliminada no final da chamada, a menos que seja preservada usando o botão Restaurar na notificação.</string>
@@ -41,7 +40,7 @@
     <string name="record_rule_type_unknown_calls_name">Chamadas Desconhecidas</string>
     <string name="record_rule_type_unknown_calls_desc">Chamadas que não correspondem a nenhum contacto.</string>
     <string name="record_rule_type_contact_name">Contacto: %s</string>
-    <string name="record_rule_type_contact_desc">Pressione longamente para remover a regra.</string>
+    <string name="record_rule_removable_desc">Pressione longamente para remover a regra.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Alterar Diretório</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -33,10 +33,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Версия</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Правила</string>
-    <string name="pref_add_rule_name">Добавить правило</string>
-    <string name="pref_add_rule_desc">Добавить правило автоматической записи для контакта.</string>
+    <string name="pref_add_contact_rule_desc">Добавить правило автоматической записи для контакта.</string>
     <string name="record_rules_rule_added">Добавлено новое правило. Нажмите и удерживайте правило, чтобы удалить его.</string>
     <string name="record_rules_rule_exists">Правило уже существует.</string>
     <string name="record_rules_info">Если правило включено, то по умолчанию запись разговора ведется автоматически и может быть удалена вручную из уведомления. Если правило выключено, запись будет удалена по окончании разговора, если она не была сохранена с помощью кнопки "Восстановить" в уведомлении.</string>
@@ -47,7 +46,7 @@
     <string name="record_rule_type_unknown_calls_name">Звонки от неизвестных</string>
     <string name="record_rule_type_unknown_calls_desc">Звонки, которые не соответствуют ни одному контакту.</string>
     <string name="record_rule_type_contact_name">Контакт: %s</string>
-    <string name="record_rule_type_contact_desc">Нажмите и удерживайте для удаления правила.</string>
+    <string name="record_rule_removable_desc">Нажмите и удерживайте для удаления правила.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Изменить папку</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -27,10 +27,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Verzia</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Pravidlá</string>
-    <string name="pref_add_rule_name">Pridať pravidlo</string>
-    <string name="pref_add_rule_desc">Pravidlo automatického nahrávania pre kontakt.</string>
+    <string name="pref_add_contact_rule_desc">Pravidlo automatického nahrávania pre kontakt.</string>
     <string name="record_rules_rule_added">Pravidlo pridané. Vymažete dlhým stlačením.</string>
     <string name="record_rules_rule_exists">Pravidlo už existuje.</string>
     <string name="record_rules_info">    Keď je pravidlo aktívne, hovory sa budú nahrávať automaticky a nahrávku práve skončeného hovoru je možné vymazať z upozornenia. Keď pravidlo nie je aktívne, nahrávky budú vždy po ukončení hovoru vymazané, jedine, že si ich ponecháte klepnutím na tlačidlo Obnoviť v upozornení.</string>
@@ -41,7 +40,7 @@
     <string name="record_rule_type_unknown_calls_name">Neznáme hovory</string>
     <string name="record_rule_type_unknown_calls_desc">Hovory, ktorých číslo nemáte v kontaktoch.</string>
     <string name="record_rule_type_contact_name">Kontakt: %s</string>
-    <string name="record_rule_type_contact_desc">Pravidlo odstránite dlhým stlačením.</string>
+    <string name="record_rule_removable_desc">Pravidlo odstránite dlhým stlačením.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Zmeniť priečinok</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -30,10 +30,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Sürüm</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Kurallar</string>
-    <string name="pref_add_rule_name">Kural ekle</string>
-    <string name="pref_add_rule_desc">Bir kişi için otomatik-kayıt kuralı ekleyin.</string>
+    <string name="pref_add_contact_rule_desc">Bir kişi için otomatik-kayıt kuralı ekleyin.</string>
     <string name="record_rules_rule_added">Yeni kural eklendi. Silmek için kurala uzun basın.</string>
     <string name="record_rules_rule_exists">Kural zaten var.</string>
     <string name="record_rules_info">Bir kural etkinleştirildiğinde, arama varsayılan olarak otomatik kaydedilir ve bildirimden manuel olarak silinebilir. Bir kural kapatıldığında, bildirimdeki Geri yükle butonu kullanılarak kaydedilmediği sürece kayıt, aramanın sonunda silinecektir.</string>
@@ -44,7 +43,7 @@
     <string name="record_rule_type_unknown_calls_name">Bilinmeyen aramalar</string>
     <string name="record_rule_type_unknown_calls_desc">Herhangi bir kişiyle eşleşmeyen aramalar.</string>
     <string name="record_rule_type_contact_name">Kişi: %s</string>
-    <string name="record_rule_type_contact_desc">Kuralı kaldırmak için uzun basın.</string>
+    <string name="record_rule_removable_desc">Kuralı kaldırmak için uzun basın.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Çıkış klasörünü değiştir</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -24,9 +24,8 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Версія</string>
 
-    <!-- Record rules bottom sheet -->
-    <string name="pref_add_rule_name">Додати правило</string>
-    <string name="pref_add_rule_desc">Додайте правило автоматичного запису для контакту.</string>
+    <!-- Record rules activity -->
+    <string name="pref_add_contact_rule_desc">Додайте правило автоматичного запису для контакту.</string>
     <string name="record_rules_rule_added">Додано нове правило. Натисніть і утримуйте правило, щоб видалити його.</string>
     <string name="record_rules_rule_exists">Правило вже існує.</string>
     <string name="record_rule_type_all_other_calls_name">Усі інші дзвінки</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -17,8 +17,7 @@
     <string name="pref_write_metadata_desc">کال کے بارے میں تفصیلات شامل کرنے والی ایک JSON فائل بنائیں اور اسے آڈیو فائل کے بجائے رکھیں۔</string>
     <string name="pref_version_name">ورژن</string>
     <string name="pref_header_rules">قواعد</string>
-    <string name="pref_add_rule_name">قاعدہ شامل کریں</string>
-    <string name="pref_add_rule_desc">ایک اتو ریکارڈ قاعدہ شخص کے لئے شامل کریں۔</string>
+    <string name="pref_add_contact_rule_desc">ایک اتو ریکارڈ قاعدہ شخص کے لئے شامل کریں۔</string>
     <string name="record_rules_rule_added">نیا قاعدہ شامل کر دیا گیا۔ اسے حذف کرنے کے لئے لانگ پریس کریں۔</string>
     <string name="record_rules_rule_exists">قاعدہ پہلے سے موجود ہے۔</string>
     <string name="record_rules_info">جب ایک قاعدہ چالو ہوتا ہے، کال خود بخود بطور افتراضی ریکارڈ ہوتی ہے اور اسے اطلاع کی زریعے سے دستیاب ریکارڈ کیسے بھی حذف کیا جا سکتا ہے۔ جب ایک قاعدہ بند ہوتا ہے، کال کے آخر میں ریکارڈ حذف کر دیا جائے گا مگر اگر آپ اطلاع کے ریاست بٹن کا استعمال کرکے اسے بحفظ کریں تو۔</string>
@@ -29,7 +28,7 @@
     <string name="record_rule_type_unknown_calls_name">نامعلوم کالوں</string>
     <string name="record_rule_type_unknown_calls_desc">کسی بھی رابطے سے مطابقت نہ کرنے والی کالیں</string>
     <string name="record_rule_type_contact_name">رابطہ: %s</string>
-    <string name="record_rule_type_contact_desc">قاعدہ ہٹانے کے لئے لانگ پریس کریں۔</string>
+    <string name="record_rule_removable_desc">قاعدہ ہٹانے کے لئے لانگ پریس کریں۔</string>
     <string name="output_dir_bottom_sheet_change_dir">ڈائریکٹری تبدیل کریں</string>
     <string name="output_dir_bottom_sheet_filename_template">فائل کا نام ٹیمپلیٹ</string>
     <string name="output_dir_bottom_sheet_edit_template">ٹیمپلیٹ میں ترمیم کریں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -30,10 +30,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">Phiên bản</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Quy tắc</string>
-    <string name="pref_add_rule_name">Thêm quy tắc</string>
-    <string name="pref_add_rule_desc">Thêm quy tắc tự động ghi âm cho một liên hệ.</string>
+    <string name="pref_add_contact_rule_desc">Thêm quy tắc tự động ghi âm cho một liên hệ.</string>
     <string name="record_rules_rule_added">Đã thêm quy tắc mới. Nhấn giữ quy tắc để xóa.</string>
     <string name="record_rules_rule_exists">Quy tắc đã tồn tại.</string>
     <string name="record_rules_info">Khi một quy tắc được bật, cuộc gọi sẽ được tự động ghi âm theo mặc định và có thể xóa thủ công từ thông báo. Khi một quy tắc bị tắt, bản ghi âm sẽ bị xóa khi cuộc gọi kết thúc trừ khi nó được giữ lại bằng cách sử dụng nút Khôi phục trong thông báo.</string>
@@ -44,7 +43,7 @@
     <string name="record_rule_type_unknown_calls_name">Cuộc gọi không xác định</string>
     <string name="record_rule_type_unknown_calls_desc">Các cuộc gọi không khớp với bất kỳ liên hệ nào.</string>
     <string name="record_rule_type_contact_name">Liên hệ: %s</string>
-    <string name="record_rule_type_contact_desc">Nhấn giữ để xóa quy tắc.</string>
+    <string name="record_rule_removable_desc">Nhấn giữ để xóa quy tắc.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Thay đổi thư mục</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -27,10 +27,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">软件版本</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">规则</string>
-    <string name="pref_add_rule_name">新增规则</string>
-    <string name="pref_add_rule_desc">从通讯录里面选择联系人添加到规则里面。</string>
+    <string name="pref_add_contact_rule_desc">从通讯录里面选择联系人添加到规则里面。</string>
     <string name="record_rules_rule_added">规则已添加。删除请长按规则。</string>
     <string name="record_rules_rule_exists">规则已存在。</string>
     <string name="record_rules_info">开启规则后，默认情况下会自动记录通话，并可以在通知中手动删除。当规则被禁用时，在通话结束时将删除记录，除非使用通知中的“还原”按钮保留记录。</string>
@@ -41,7 +40,7 @@
     <string name="record_rule_type_unknown_calls_name">未知号码</string>
     <string name="record_rule_type_unknown_calls_desc">未匹配任何联系人的通话。</string>
     <string name="record_rule_type_contact_name">联系人: %s</string>
-    <string name="record_rule_type_contact_desc">长按以移除规则</string>
+    <string name="record_rule_removable_desc">长按以移除规则</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">修改</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -30,10 +30,9 @@
     <!-- About "preference" -->
     <string name="pref_version_name">版本</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Record rules activity -->
     <string name="pref_header_rules">規則</string>
-    <string name="pref_add_rule_name">加入規則</string>
-    <string name="pref_add_rule_desc">加入聯絡人的自動錄音規則。</string>
+    <string name="pref_add_contact_rule_desc">加入聯絡人的自動錄音規則。</string>
     <string name="record_rules_rule_added">已加入新規則。長按規則以將其刪除。</string>
     <string name="record_rules_rule_exists">規則已存在。</string>
     <string name="record_rules_info">若啟用規則，預設會自動錄製通話，並可以在通知中手動刪除。若停用規則，通話結束時會刪除錄音檔，可按下通知中的還原按鈕保留錄音檔。</string>
@@ -44,7 +43,7 @@
     <string name="record_rule_type_unknown_calls_name">未知通話</string>
     <string name="record_rule_type_unknown_calls_desc">不符合任何聯絡人的通話。</string>
     <string name="record_rule_type_contact_name">聯絡人：%s</string>
-    <string name="record_rule_type_contact_desc">長按以移除規則。</string>
+    <string name="record_rule_removable_desc">長按以移除規則。</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">變更目錄</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,10 +48,15 @@
     <string name="pref_migrate_direct_boot_name">Migrate direct boot recordings</string>
     <string name="pref_migrate_direct_boot_desc">Migrate recordings made before the first unlock. This normally happens automatically after the first unlock.</string>
 
-    <!-- Record rules bottom sheet -->
+    <!-- Pick contact group activity -->
+    <string name="pick_contact_group_title">Pick contact group</string>
+
+    <!-- Record rules activity -->
     <string name="pref_header_rules">Rules</string>
-    <string name="pref_add_rule_name">Add rule</string>
-    <string name="pref_add_rule_desc">Add an auto-record rule for a contact.</string>
+    <string name="pref_add_contact_rule_name">Add contact rule</string>
+    <string name="pref_add_contact_rule_desc">Add an auto-record rule for a contact.</string>
+    <string name="pref_add_contact_group_rule_name">Add contact group rule</string>
+    <string name="pref_add_contact_group_rule_desc">Add an auto-record rule for a contact group.</string>
     <string name="record_rules_rule_added">Added new rule. Long press the rule to delete it.</string>
     <string name="record_rules_rule_exists">Rule already exists.</string>
     <string name="record_rules_info">When a rule is turned on, the call is automatically recorded by default and can be manually deleted from the notification. When a rule is turned off, the recording will be deleted at the end of a call unless it is preserved using the Restore button in the notification.</string>
@@ -62,7 +67,8 @@
     <string name="record_rule_type_unknown_calls_name">Unknown calls</string>
     <string name="record_rule_type_unknown_calls_desc">Calls that don\'t match any contact.</string>
     <string name="record_rule_type_contact_name">Contact: %s</string>
-    <string name="record_rule_type_contact_desc">Long press to remove rule.</string>
+    <string name="record_rule_type_contact_group_name">Contact group: %s</string>
+    <string name="record_rule_removable_desc">Long press to remove rule.</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Change directory</string>

--- a/app/src/main/res/xml/record_rules_preferences.xml
+++ b/app/src/main/res/xml/record_rules_preferences.xml
@@ -12,10 +12,17 @@
         app:iconSpaceReserved="false">
 
         <Preference
-            app:key="add_rule"
+            app:key="add_contact_rule"
             app:persistent="false"
-            app:title="@string/pref_add_rule_name"
-            app:summary="@string/pref_add_rule_desc"
+            app:title="@string/pref_add_contact_rule_name"
+            app:summary="@string/pref_add_contact_rule_desc"
+            app:iconSpaceReserved="false" />
+
+        <Preference
+            app:key="add_contact_group_rule"
+            app:persistent="false"
+            app:title="@string/pref_add_contact_group_rule_name"
+            app:summary="@string/pref_add_contact_group_rule_desc"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This is unfortunately a relatively big change because unlike single contacts, Android does not provide a standard intent for apps to select a contact group. We have to implement our own contact group picker UI.

Following our current convention, the most specific rule wins as a side effect of how rules are sorted. If a call matches both a contact and a contact group, the contact rule has higher precedence.

Fixes: #536