### PR TITLE
DocumentFileExtensions: Fix Cursor resource leak

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/extension/CursorExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/CursorExtensions.kt
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.bcr.extension
+
+import android.database.Cursor
+
+fun Cursor.asSequence() = generateSequence(seed = takeIf { it.moveToFirst() }) {
+    takeIf { it.moveToNext() }
+}


### PR DESCRIPTION
The original idea was fundamentally not workable. Nothing would cause the `use { ... }` block to end immediately after we stop consuming the iterator. I'm too used to languages with RAII.