### PR TITLE
Notifications: Avoid overriding expanded notification text

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -152,7 +152,7 @@ class Notifications(
             setContentTitle(context.getText(titleResId))
             if (message != null) {
                 setContentText(message)
-                style = Notification.BigTextStyle().bigText(message)
+                style = Notification.BigTextStyle()
             }
             setSmallIcon(R.drawable.ic_launcher_quick_settings)
             setContentIntent(pendingIntent)


### PR DESCRIPTION
We don't use a different expanded notification message, so the default behavior is sufficient.