### PR TITLE
Contact.kt: The SOURCE_ID for groups is allowed to be null

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Contact.kt
+++ b/app/src/main/java/com/chiller3/bcr/Contact.kt
@@ -32,6 +32,7 @@ private val CONTACT_GROUP_PROJECTION = arrayOf(
     ContactsContract.Groups._ID,
     ContactsContract.Groups.SOURCE_ID,
     ContactsContract.Groups.TITLE,
+    ContactsContract.Groups.ACCOUNT_NAME,
 )
 
 data class ContactInfo(
@@ -50,6 +51,7 @@ data class ContactGroupInfo(
     val rowId: Long,
     val sourceId: String?,
     val title: String,
+    val accountName: String?,
 ) : Parcelable
 
 @RequiresPermission(Manifest.permission.READ_CONTACTS)
@@ -174,12 +176,14 @@ fun <R> withContactGroups(
         val indexRowId = cursor.getColumnIndexOrThrow(ContactsContract.Groups._ID)
         val indexSourceId = cursor.getColumnIndexOrThrow(ContactsContract.Groups.SOURCE_ID)
         val indexTitle = cursor.getColumnIndexOrThrow(ContactsContract.Groups.TITLE)
+        val indexAccountName = cursor.getColumnIndexOrThrow(ContactsContract.Groups.ACCOUNT_NAME)
 
         block(cursor.asSequence().map {
             ContactGroupInfo(
                 cursor.getLong(indexRowId),
                 cursor.getStringOrNull(indexSourceId),
                 cursor.getString(indexTitle),
+                cursor.getStringOrNull(indexAccountName),
             )
         })
     }

--- a/app/src/main/java/com/chiller3/bcr/Contact.kt
+++ b/app/src/main/java/com/chiller3/bcr/Contact.kt
@@ -48,7 +48,7 @@ sealed interface GroupLookup {
 @Parcelize
 data class ContactGroupInfo(
     val rowId: Long,
-    val sourceId: String,
+    val sourceId: String?,
     val title: String,
 ) : Parcelable
 
@@ -178,7 +178,7 @@ fun <R> withContactGroups(
         block(cursor.asSequence().map {
             ContactGroupInfo(
                 cursor.getLong(indexRowId),
-                cursor.getString(indexSourceId),
+                cursor.getStringOrNull(indexSourceId),
                 cursor.getString(indexTitle),
             )
         })

--- a/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupFragment.kt
@@ -59,6 +59,7 @@ class PickContactGroupFragment : PreferenceBaseFragment(), Preference.OnPreferen
                 key = PREF_GROUP_PREFIX + i
                 isPersistent = false
                 title = group.title
+                summary = group.accountName ?: getString(R.string.pick_contact_group_local_group)
                 isIconSpaceReserved = false
                 onPreferenceClickListener = this@PickContactGroupFragment
             }

--- a/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupViewModel.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/PickContactGroupViewModel.kt
@@ -40,6 +40,7 @@ class PickContactGroupViewModel(application: Application) : AndroidViewModel(app
                                     o1,
                                     o2,
                                     { it.title },
+                                    { it.accountName },
                                     { it.rowId },
                                     { it.sourceId },
                                 )

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
@@ -91,7 +91,7 @@ sealed class RecordRule {
 
     data class ContactGroup(
         val rowId: Long,
-        val sourceId: String,
+        val sourceId: String?,
         override val record: Boolean,
     ) : RecordRule() {
         override fun matches(
@@ -123,7 +123,6 @@ sealed class RecordRule {
 
                 val prefSourceId = prefix + PREF_SUFFIX_CONTACT_GROUP_SOURCE_ID
                 val sourceId = prefs.getString(prefSourceId, null)
-                    ?: throw IllegalStateException("Missing $prefSourceId")
 
                 val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
 

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
@@ -164,7 +164,7 @@ class RecordRulesFragment : PreferenceBaseFragment(), Preference.OnPreferenceCli
                     is DisplayedRecordRule.ContactGroup -> {
                         title = getString(
                             R.string.record_rule_type_contact_group_name,
-                            rule.title ?: rule.sourceId,
+                            rule.title ?: rule.sourceId ?: rule.rowId.toString(),
                         )
                         summary = getString(R.string.record_rule_removable_desc)
                         isEnabled = contactsGranted

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
@@ -162,10 +162,19 @@ class RecordRulesFragment : PreferenceBaseFragment(), Preference.OnPreferenceCli
                         onPreferenceLongClickListener = this@RecordRulesFragment
                     }
                     is DisplayedRecordRule.ContactGroup -> {
-                        title = getString(
-                            R.string.record_rule_type_contact_group_name,
-                            rule.title ?: rule.sourceId ?: rule.rowId.toString(),
-                        )
+                        title = if (rule.title != null) {
+                            getString(
+                                R.string.record_rule_type_contact_group_name_with_account,
+                                rule.title,
+                                rule.accountName
+                                    ?: getString(R.string.pick_contact_group_local_group),
+                            )
+                        } else {
+                            getString(
+                                R.string.record_rule_type_contact_group_name,
+                                rule.sourceId ?: rule.rowId.toString(),
+                            )
+                        }
                         summary = getString(R.string.record_rule_removable_desc)
                         isEnabled = contactsGranted
                         onPreferenceLongClickListener = this@RecordRulesFragment

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesViewModel.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesViewModel.kt
@@ -87,7 +87,7 @@ sealed class DisplayedRecordRule : Comparable<DisplayedRecordRule> {
     data class ContactGroup(
         val title: String?,
         val rowId: Long,
-        val sourceId: String,
+        val sourceId: String?,
         override var record: Boolean,
     ) : DisplayedRecordRule() {
         override val sortCategory: Int = 2
@@ -134,7 +134,7 @@ class RecordRulesViewModel(application: Application) : AndroidViewModel(applicat
                                 rule.record,
                             )
                             is RecordRule.ContactGroup -> DisplayedRecordRule.ContactGroup(
-                                getContactGroupTitle(rule.sourceId),
+                                getContactGroupTitle(rule.rowId, rule.sourceId),
                                 rule.rowId,
                                 rule.sourceId,
                                 rule.record,
@@ -193,14 +193,20 @@ class RecordRulesViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
-    private fun getContactGroupTitle(sourceId: String): String? {
+    private fun getContactGroupTitle(rowId: Long, sourceId: String?): String? {
         if (getApplication<Application>().checkSelfPermission(Manifest.permission.READ_CONTACTS)
             != PackageManager.PERMISSION_GRANTED) {
             return null
         }
 
+        val groupLookup = if (sourceId != null) {
+            GroupLookup.SourceId(sourceId)
+        } else {
+            GroupLookup.RowId(rowId)
+        }
+
         return try {
-            getContactGroupById(getApplication(), GroupLookup.SourceId(sourceId))?.title
+            getContactGroupById(getApplication(), groupLookup)?.title
         } catch (e: Exception) {
             Log.w(TAG, "Failed to look up contact group", e)
             null

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,6 +68,7 @@
     <string name="record_rule_type_unknown_calls_desc">Appels ne correspondant à aucun contact.</string>
     <string name="record_rule_type_contact_name">Contact : %s</string>
     <string name="record_rule_type_contact_group_name">Groupe de contact : %s</string>
+    <string name="record_rule_type_contact_group_name_with_account">Groupe de contact : %1$s (%2$s)</string>
     <string name="record_rule_removable_desc">Maintenir appuyé pour supprimer la règle.</string>
 
     <!-- Output directory bottom sheet -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -69,6 +69,7 @@
     <string name="record_rule_type_unknown_calls_desc">Apeluri care nu sunt asociate cu niciun contact.</string>
     <string name="record_rule_type_contact_name">Contact: %s</string>
     <string name="record_rule_type_contact_group_name">Grup de contact: %s</string>
+    <string name="record_rule_type_contact_group_name_with_account">Grup de contact: %1$s (%2$s)</string>
     <string name="record_rule_removable_desc">Apăsați lung pentru a elimina regula.</string>
 
     <!-- Output directory bottom sheet -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
 
     <!-- Pick contact group activity -->
     <string name="pick_contact_group_title">Pick contact group</string>
+    <string name="pick_contact_group_local_group">Local group</string>
 
     <!-- Record rules activity -->
     <string name="pref_header_rules">Rules</string>
@@ -75,6 +76,7 @@
     <string name="record_rule_type_unknown_calls_desc">Calls that don\'t match any contact.</string>
     <string name="record_rule_type_contact_name">Contact: %s</string>
     <string name="record_rule_type_contact_group_name">Contact group: %s</string>
+    <string name="record_rule_type_contact_group_name_with_account">Contact group: %1$s (%2$s)</string>
     <string name="record_rule_removable_desc">Long press to remove rule.</string>
 
     <!-- Output directory bottom sheet -->


### PR DESCRIPTION
Android does not require accounts to set the SOURCE_ID for groups. This previously caused the group list query to fail, leading to an empty contact group picker screen.

Fixes: #620