### PR TITLE
Use sysconfig file in addition to android:usesNonSdkApi

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -309,6 +309,22 @@ android.applicationVariants.all {
         }
     }
 
+    val configXml = tasks.register("configXml${capitalized}") {
+        inputs.property("variant.applicationId", variant.applicationId)
+
+        val outputFile = variantDir.map { it.file("config-${variant.applicationId}.xml") }
+        outputs.file(outputFile)
+
+        doLast {
+            outputFile.get().asFile.writeText("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <config>
+                    <hidden-api-whitelisted-app package="${variant.applicationId}" />
+                </config>
+            """.trimIndent())
+        }
+    }
+
     val addonD = tasks.register("addonD${capitalized}") {
         inputs.property("variant.applicationId", variant.applicationId)
 
@@ -322,6 +338,7 @@ android.applicationVariants.all {
             "priv-app/${variant.applicationId}/${it.outputFile.name}"
         } + listOf(
             "etc/permissions/privapp-permissions-${variant.applicationId}.xml",
+            "etc/sysconfig/config-${variant.applicationId}.xml",
         )
 
         doLast {
@@ -369,6 +386,9 @@ android.applicationVariants.all {
         }
         from(permissionsXml.map { it.outputs }) {
             into("system/etc/permissions")
+        }
+        from(configXml.map { it.outputs }) {
+            into("system/etc/sysconfig")
         }
         from(variant.outputs.map { it.outputFile }) {
             into("system/priv-app/${variant.applicationId}")

--- a/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
@@ -18,8 +18,10 @@ val AudioFormat.frameSizeInBytesCompat: Int
         2 * channelCount
     }
 
-// Static extension functions are currently not supported in Kotlin. Also, we set usesNonSdkApi to
-// allow access to these hidden fields.
+// Static extension functions are currently not supported in Kotlin. Also, we both install a
+// sysconfig file and set usesNonSdkApi to allow access to these hidden fields. The usesNonSdkApi
+// flag is more reliable, but the sysconfig file is needed on older versions of Android that are
+// missing AOSP commit ca6f81d39525174e926c2fcc824fe9531ffb3563.
 
 @SuppressLint("SoonBlockedPrivateApi")
 val SAMPLE_RATE_HZ_MIN_COMPAT: Int =


### PR DESCRIPTION
Older versions of Android 9 are missing the the AOSP commit that added support for android:usesNonSdkApi.

https://android.googlesource.com/platform/frameworks/base/+/ca6f81d39525174e926c2fcc824fe9531ffb3563%5E%21/

This partially reverts commit 9823a982c0bb1948e22bcc80886dba656988a986.

Fixes: #628