### PR TITLE
Manually handle audio/mp4 file extension in older versions of Android

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/DirectBootMigrationService.kt
+++ b/app/src/main/java/com/chiller3/bcr/DirectBootMigrationService.kt
@@ -13,6 +13,8 @@ import android.os.Looper
 import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.documentfile.provider.DocumentFile
+import com.chiller3.bcr.extension.getExtensionFromMimeTypeCompat
+import com.chiller3.bcr.extension.hasExtensionCompat
 import com.chiller3.bcr.format.Format
 import com.chiller3.bcr.output.OutputDirUtils
 import com.chiller3.bcr.output.OutputFile
@@ -24,7 +26,7 @@ class DirectBootMigrationService : Service() {
         private val TAG = DirectBootMigrationService::class.java.simpleName
 
         private fun isKnownExtension(extension: String): Boolean {
-            return extension == "log" || MimeTypeMap.getSingleton().hasExtension(extension)
+            return extension == "log" || MimeTypeMap.getSingleton().hasExtensionCompat(extension)
         }
 
         private fun splitKnownExtension(name: String): Pair<String, String> {
@@ -58,7 +60,7 @@ class DirectBootMigrationService : Service() {
             }
 
             return knownMimeTypes.find {
-                MimeTypeMap.getSingleton().getExtensionFromMimeType(it.type) == extension
+                MimeTypeMap.getSingleton().getExtensionFromMimeTypeCompat(it.type) == extension
             }
         }
     }

--- a/app/src/main/java/com/chiller3/bcr/extension/MimeTypeMapExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/MimeTypeMapExtensions.kt
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.bcr.extension
+
+import android.webkit.MimeTypeMap
+
+private val MIME_TYPES_COMPAT = hashMapOf(
+    // Android 9 and 10 didn't switch to mime-support [1] yet. Instead, their MimeTypeMap used
+    // MimeUtils, which supported significantly fewer MIME types.
+    // [1] https://android.googlesource.com/platform/external/mime-support/+/refs/heads/main/mime.types
+    // [2] https://android.googlesource.com/platform/libcore/+/refs/tags/android-9.0.0_r61/luni/src/main/java/libcore/net/MimeUtils.java
+    "audio/mp4" to "m4a",
+)
+
+fun MimeTypeMap.hasExtensionCompat(extension: String): Boolean =
+    hasExtension(extension) || extension in MIME_TYPES_COMPAT.values
+
+fun MimeTypeMap.getExtensionFromMimeTypeCompat(mimeType: String): String? =
+    getExtensionFromMimeType(mimeType) ?: MIME_TYPES_COMPAT[mimeType]

--- a/app/src/main/java/com/chiller3/bcr/extension/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/UriExtensions.kt
@@ -20,7 +20,7 @@ val Uri.formattedString: String
         ContentResolver.SCHEME_FILE -> path!!
         ContentResolver.SCHEME_CONTENT -> {
             val prefix = when (authority) {
-                "com.android.externalstorage.documents" -> ""
+                DOCUMENTSUI_AUTHORITY -> ""
                 // Include the authority to reduce ambiguity when this isn't a SAF URI provided by
                 // Android's local filesystem document provider
                 else -> "[$authority] "

--- a/app/src/main/java/com/chiller3/bcr/output/OutputDirUtils.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputDirUtils.kt
@@ -20,6 +20,7 @@ import com.chiller3.bcr.extension.createNestedFile
 import com.chiller3.bcr.extension.deleteIfEmptyDirRecursively
 import com.chiller3.bcr.extension.findNestedFile
 import com.chiller3.bcr.extension.findOrCreateDirectories
+import com.chiller3.bcr.extension.getExtensionFromMimeTypeCompat
 import com.chiller3.bcr.extension.moveToDirectory
 import com.chiller3.bcr.extension.renameToPreserveExt
 import com.chiller3.bcr.extension.toDocumentFile
@@ -143,8 +144,9 @@ class OutputDirUtils(private val context: Context, private val redactor: Redacto
         try {
             val targetFile = sourceFile.moveToDirectory(targetParent)
             if (targetFile != null) {
-                val hasExt =
-                    !MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType).isNullOrEmpty()
+                val hasExt = !MimeTypeMap.getSingleton()
+                    .getExtensionFromMimeTypeCompat(mimeType)
+                    .isNullOrEmpty()
 
                 // We behave like SAF where the target path does not contain the file extension, but
                 // querying the current filename does contain the file extension. Only chop off the


### PR DESCRIPTION
Android 9 and 10 support a much smaller list of MIME types because they hadn't migrated to the mime-support package yet (used by most Linux distros). With this commit, BCR will explicitly append the file extension for `audio/mp4` when saving to local storage. Other document providers don't get this special treatment because there is no way to determine which MIME types they support.