### PR TITLE
Fix crash when contact query fails in direct boot mode

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/output/CallMetadataCollector.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/CallMetadataCollector.kt
@@ -60,7 +60,12 @@ class CallMetadataCollector(
 
         Log.d(TAG, "Performing manual contact lookup")
 
-        val contact = withContactsByPhoneNumber(context, number) { it.firstOrNull() }
+        val contact = try {
+            withContactsByPhoneNumber(context, number) { it.firstOrNull() }
+        } catch (e: Exception) {
+            Log.d(TAG, "Failed to look up contact", e)
+            return null
+        }
         if (contact == null) {
             Log.d(TAG, "Contact not found via manual lookup")
             return null

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
@@ -5,10 +5,8 @@
 
 package com.chiller3.bcr.rule
 
-import android.Manifest
 import android.content.Context
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
 import android.os.Parcelable
 import android.util.Log
 import com.chiller3.bcr.GroupLookup
@@ -169,12 +167,10 @@ data class RecordRule(
             direction: CallDirection?,
             simSlot: Int?,
         ): Action {
-            val contactsAllowed = context.checkSelfPermission(Manifest.permission.READ_CONTACTS) ==
-                    PackageManager.PERMISSION_GRANTED
             var contactLookupKeys = emptySet<String>()
             var contactGroupIds = emptySet<GroupLookup>()
 
-            if (contactsAllowed) {
+            try {
                 contactLookupKeys = hashSetOf<String>().apply {
                     for (number in numbers) {
                         withContactsByPhoneNumber(context, number) { contacts ->
@@ -193,8 +189,10 @@ data class RecordRule(
                         }
                     }
                 }
-            } else {
-                Log.i(TAG, "Contacts permission not granted")
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Permission denied when querying contacts and contact groups", e)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to query contacts and contact groups", e)
             }
 
             for (rule in rules) {


### PR DESCRIPTION
This regressed after de0bd10c49e58f5ab6e9c7a0948a79bd1d2e3d5e, which turned null `Cursor` return values from `ContentResolver` queries into exceptions.

This updates the CallMetadataCollector (and RecordRule) queries to catch exceptions when querying contacts.

Fixes: #643