### PR TITLE
Remove migration for the legacy global sample rate option

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -55,7 +55,6 @@ class Preferences(initialContext: Context) {
         private const val PREF_FORMAT_PARAM_PREFIX = "codec_param_"
         private const val PREF_FORMAT_SAMPLE_RATE_PREFIX = "codec_sample_rate_"
         const val PREF_OUTPUT_RETENTION = "output_retention"
-        const val PREF_SAMPLE_RATE = "sample_rate"
         private const val PREF_NEXT_NOTIFICATION_ID = "next_notification_id"
         private const val PREF_ALREADY_MIGRATED = "already_migrated"
 
@@ -445,20 +444,6 @@ class Preferences(initialContext: Context) {
             prefs.edit { putInt(PREF_NEXT_NOTIFICATION_ID, nextId + 1) }
             nextId
         }
-
-    /**
-     * Migrate legacy global sample rate to format-specific sample rate.
-     *
-     * This migration will be removed in version 1.65.
-     */
-    fun migrateSampleRate() {
-        val sampleRate = getOptionalUint(PREF_SAMPLE_RATE, UInt.MAX_VALUE)
-        if (sampleRate != null) {
-            val (format, _, _) = Format.fromPreferences(this)
-            setFormatSampleRate(format, sampleRate)
-            setOptionalUint(PREF_SAMPLE_RATE, UInt.MAX_VALUE, null)
-        }
-    }
 
     /**
      * Migrate legacy rules to modern rules.

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -48,7 +48,6 @@ class RecorderApplication : Application() {
 
         // Migrate legacy preferences.
         val prefs = Preferences(this)
-        prefs.migrateSampleRate()
         prefs.migrateLegacyRules()
     }
 

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -310,7 +310,7 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
                 refreshOutputDir()
             }
             // Update the output format state when it's changed by the bottom sheet.
-            Preferences.isFormatKey(key) || key == Preferences.PREF_SAMPLE_RATE -> {
+            Preferences.isFormatKey(key) -> {
                 refreshOutputFormat()
             }
             // Update when it's changed by the dialog.


### PR DESCRIPTION
This was originally planned for version 1.65, so it's quite overdue.