### PR TITLE
Remove check for FEATURE_TELEPHONY_SUBSCRIPTION

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/output/CallMetadataCollector.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/CallMetadataCollector.kt
@@ -232,9 +232,7 @@ class CallMetadataCollector(
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
             && context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
-                == PackageManager.PERMISSION_GRANTED
-            && context.packageManager.hasSystemFeature(
-                PackageManager.FEATURE_TELEPHONY_SUBSCRIPTION)) {
+                == PackageManager.PERMISSION_GRANTED) {
             val subscriptionManager = context.getSystemService(SubscriptionManager::class.java)
 
             val telephonyManager = context.getSystemService(TelephonyManager::class.java)

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRuleEditorBottomSheet.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRuleEditorBottomSheet.kt
@@ -276,9 +276,7 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
             && context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
-                == PackageManager.PERMISSION_GRANTED
-            && context.packageManager.hasSystemFeature(
-                PackageManager.FEATURE_TELEPHONY_SUBSCRIPTION)) {
+                == PackageManager.PERMISSION_GRANTED) {
             val subscriptionManager = context.getSystemService(SubscriptionManager::class.java)
 
             val actualSimCount = subscriptionManager.activeSubscriptionInfoCount


### PR DESCRIPTION
OxygenOS doesn't advertise support for it, but supports it anyway. Let's just assume that all Android versions capable of supporting SubscriptionManager actually support it. AOSP's Settings app doesn't check for this feature either.

Fixes: #649