### PR TITLE
Add wall duration to metadata JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ The JSON structure is shown in the following example. Note that only `timestamp_
             // because no device supports stereo call audio.
             "channel_count": 1,
 
+            // The total wall time from when the recording process began to when
+            // it ended. If duration_secs_total is significantly lower than this
+            // value, then Android sent less audio to BCR than expected.
+            "duration_secs_wall": 3.0,
+
             // The total time in seconds that BCR read from the audio device.
             // (Equal to: frames_total / sample_rate / channel_count)
             "duration_secs_total": 2.0,

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -21,9 +21,8 @@ import com.chiller3.bcr.output.Retention
 import com.chiller3.bcr.rule.LegacyRecordRule
 import com.chiller3.bcr.rule.RecordRule
 import com.chiller3.bcr.template.Template
-import kotlinx.serialization.encodeToString
-import java.io.File
 import kotlinx.serialization.json.Json
+import java.io.File
 
 class Preferences(initialContext: Context) {
     companion object {

--- a/app/src/main/java/com/chiller3/bcr/output/CallMetadata.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/CallMetadata.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -127,6 +127,8 @@ data class RecordingJson(
     val sampleRate: Int,
     @SerialName("channel_count")
     val channelCount: Int,
+    @SerialName("duration_secs_wall")
+    val durationSecsWall: Double,
     @SerialName("duration_secs_total")
     val durationSecsTotal: Double,
     @SerialName("duration_secs_encoded")


### PR DESCRIPTION
This measures the total wall time from when the recording started to when the recording ended. If this is significantly higher than the actual duration of the recording, then Android is failing to send the correct amount of audio to BCR.