### PR TITLE
Remove Google Play dependency info block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -192,6 +192,10 @@ android {
         // added to values/strings.xml
         disable += "MissingTranslation"
     }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 kotlin {


### PR DESCRIPTION
This metadata is encrypted with Google's public key and is unreadable by anyone else. We have no need for this.