### PR TITLE
Refresh file retention setting when resetting filename template

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryBottomSheetFragment.kt
@@ -62,6 +62,7 @@ class OutputDirectoryBottomSheetFragment : BottomSheetDialogFragment() {
         binding.editTemplate.setOnLongClickListener {
             prefs.filenameTemplate = null
             refreshFilenameTemplate()
+            refreshOutputRetention()
             true
         }
 


### PR DESCRIPTION
Without this, if the user:

1. sets a filename template that's incompatible with file retention
2. resets the template by long pressing the file retention setting

then the file retention setting stays disabled with an error until the bottom sheet fragment is reloaded.