### PR TITLE
Show path in notifications when SAF URIs are meaningless

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/DirectBootMigrationService.kt
+++ b/app/src/main/java/com/chiller3/bcr/DirectBootMigrationService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -205,6 +205,7 @@ class DirectBootMigrationService : Service() {
                         OutputFile(
                             newFile.uri,
                             redactor.redact(newFile.uri),
+                            fileInfo.path.joinToString("/"),
                             fileInfo.mime.type,
                         )
                     )

--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -229,6 +229,14 @@ class Notifications(
                 }
                 if (file != null) {
                     if (isNotEmpty()) {
+                        append("\n\n")
+                    }
+
+                    // Some SAF providers have document IDs that aren't paths (eg. auto-incrementing
+                    // number) and are meaningless to the user.
+                    val formattedUri = file.uri.formattedString
+                    if (!formattedUri.contains(file.path)) {
+                        append(file.path)
                         append("\n\n")
                     }
                     append(file.uri.formattedString)

--- a/app/src/main/java/com/chiller3/bcr/output/OutputFile.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputFile.kt
@@ -24,6 +24,12 @@ data class OutputFile(
     /** String representation of [uri] with private information redacted. */
     val redacted: String,
 
+    /**
+     * Path of the file referred to by [uri]. Displayed to the user when [uri] does not contain a
+     * meaningful path.
+     */
+    val path: String,
+
     /** MIME type of [uri]'s contents. */
     val mimeType: String,
 ) : Parcelable {


### PR DESCRIPTION
Some SAF providers use an auto-incrementing integer as the document UI instead of a path that's meaningful to the user.