### PR TITLE
Hardcode supported sample rates for WAV/PCM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -301,22 +301,6 @@ android.applicationVariants.all {
         }
     }
 
-    val configXml = tasks.register("configXml${capitalized}") {
-        inputs.property("variant.applicationId", variant.applicationId)
-
-        val outputFile = variantDir.map { it.file("config-${variant.applicationId}.xml") }
-        outputs.file(outputFile)
-
-        doLast {
-            outputFile.get().asFile.writeText("""
-                <?xml version="1.0" encoding="utf-8"?>
-                <config>
-                    <hidden-api-whitelisted-app package="${variant.applicationId}" />
-                </config>
-            """.trimIndent())
-        }
-    }
-
     val addonD = tasks.register("addonD${capitalized}") {
         inputs.property("variant.applicationId", variant.applicationId)
 
@@ -330,7 +314,6 @@ android.applicationVariants.all {
             "priv-app/${variant.applicationId}/${it.outputFile.name}"
         } + listOf(
             "etc/permissions/privapp-permissions-${variant.applicationId}.xml",
-            "etc/sysconfig/config-${variant.applicationId}.xml",
         )
 
         doLast {
@@ -378,9 +361,6 @@ android.applicationVariants.all {
         }
         from(permissionsXml.map { it.outputs }) {
             into("system/etc/permissions")
-        }
-        from(configXml.map { it.outputs }) {
-            into("system/etc/sysconfig")
         }
         from(variant.outputs.map { it.outputFile }) {
             into("system/priv-app/${variant.applicationId}")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,16 +30,8 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <!--
-        We use android:usesNonSdkApi to bypass Android's hidden API restrictions instead of creating
-        a sysconfig file with <hidden-api-whitelisted-app>. This is necessary because some custom
-        Android builds have a bug where the sysconfig file is only sometimes respected, leading to
-        intermittent app crashes.
-    -->
-    <!--suppress AndroidUnknownAttribute -->
     <application
         android:name=".RecorderApplication"
-        android:usesNonSdkApi="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/AudioFormatExtensions.kt
@@ -5,7 +5,6 @@
 
 package com.chiller3.bcr.extension
 
-import android.annotation.SuppressLint
 import android.media.AudioFormat
 import android.os.Build
 
@@ -17,16 +16,3 @@ val AudioFormat.frameSizeInBytesCompat: Int
         assert(encoding == AudioFormat.ENCODING_PCM_16BIT)
         2 * channelCount
     }
-
-// Static extension functions are currently not supported in Kotlin. Also, we both install a
-// sysconfig file and set usesNonSdkApi to allow access to these hidden fields. The usesNonSdkApi
-// flag is more reliable, but the sysconfig file is needed on older versions of Android that are
-// missing AOSP commit ca6f81d39525174e926c2fcc824fe9531ffb3563.
-
-@SuppressLint("SoonBlockedPrivateApi")
-val SAMPLE_RATE_HZ_MIN_COMPAT: Int =
-    AudioFormat::class.java.getDeclaredField("SAMPLE_RATE_HZ_MIN").getInt(null)
-
-@SuppressLint("SoonBlockedPrivateApi")
-val SAMPLE_RATE_HZ_MAX_COMPAT: Int =
-    AudioFormat::class.java.getDeclaredField("SAMPLE_RATE_HZ_MAX").getInt(null)

--- a/app/src/main/java/com/chiller3/bcr/format/WaveFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/WaveFormat.kt
@@ -6,8 +6,6 @@
 package com.chiller3.bcr.format
 
 import android.media.MediaFormat
-import com.chiller3.bcr.extension.SAMPLE_RATE_HZ_MAX_COMPAT
-import com.chiller3.bcr.extension.SAMPLE_RATE_HZ_MIN_COMPAT
 import java.io.FileDescriptor
 
 data object WaveFormat : Format() {
@@ -23,8 +21,8 @@ data object WaveFormat : Format() {
     override val sampleRateInfo: SampleRateInfo = RangedSampleRateInfo(
         // WAV sample rate field is a 4-byte integer and there's nothing that theoretically prevents
         // using an absurdly large sample rate. However, let's stick to a range that AudioRecord
-        // actually supports.
-        arrayOf(SAMPLE_RATE_HZ_MIN_COMPAT.toUInt()..SAMPLE_RATE_HZ_MAX_COMPAT.toUInt()),
+        // actually supports. See system/media/audio/include/system/audio.h in AOSP.
+        arrayOf(4_000u..192_000u),
         16_000u,
     )
 


### PR DESCRIPTION
Works around broken root hiding mechanisms that make the sysconfig file invisible to the system.

Closes: #733