### PR TITLE
Remove "Disable battery optimizations" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ BCR is a simple Android call recording app for rooted devices or devices running
 * Direct boot aware (records calls prior to first unlock after a reboot)
 * Auto-record rules
 * Quick settings toggle
-* Material You dynamic theming
 * No persistent notification unless a recording is in progress
 * No network access permission
 * Supports both Magisk and KernelSU
@@ -35,7 +34,6 @@ As the name alludes, BCR intends to be a basic as possible. The project will hav
 * Support for old Android versions (support is dropped as soon as maintenance becomes cumbersome)
 * Workarounds for [OEM-specific battery optimization and app killing behavior](https://dontkillmyapp.com/)
 * Workarounds for devices that don't support the [`VOICE_CALL` audio source](https://developer.android.com/reference/android/media/MediaRecorder.AudioSource#VOICE_CALL) (eg. using microphone + speakerphone)
-* Support for direct boot mode (the state before the device is initially unlocked after reboot)
 * Support for stock, unrooted firmware
 
 ## Usage
@@ -118,10 +116,6 @@ Note that the output directory is not available before the device is unlocked fo
   * Needed to automatically move recordings made before the initial device unlock to the output directory.
 * `READ_PHONE_STATE` (**optional**)
   * If allowed, the SIM slot for devices with multiple active SIMs is added to the output filename.
-* `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (**optional**)
-  * If allowed, request Android to disable battery optimizations (app killing) for BCR.
-  * This is usually not needed. The way BCR hooks into the telephony system makes it unlikely to be killed.
-  * OEM Android builds that stray further from AOSP may ignore this.
 * `VIBRATE` (**automatically granted at install time**)
   * If vibration is enabled for BCR's notifications in Android's settings, BCR will perform the vibration. Android itself does not respect the vibration option when a phone call is active.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2022-2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2022-2026 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -27,7 +27,6 @@
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application

--- a/app/src/main/java/com/chiller3/bcr/Permissions.kt
+++ b/app/src/main/java/com/chiller3/bcr/Permissions.kt
@@ -1,18 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.bcr
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
-import android.os.PowerManager
 import android.provider.Settings
 import androidx.core.content.ContextCompat
 
@@ -40,34 +38,10 @@ object Permissions {
         }
 
     /**
-     * Check if battery optimizations are currently disabled for this app.
-     */
-    fun isInhibitingBatteryOpt(context: Context): Boolean {
-        val pm: PowerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-        return pm.isIgnoringBatteryOptimizations(context.packageName)
-    }
-
-    /**
      * Get intent for opening the app info page in the system settings.
      */
     fun getAppInfoIntent(context: Context) = Intent(
         Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
         Uri.fromParts("package", context.packageName, null),
-    )
-
-    /**
-     * Get intent for requesting the disabling of battery optimization for this app.
-     */
-    @SuppressLint("BatteryLife")
-    fun getInhibitBatteryOptIntent(context: Context) = Intent(
-        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-        Uri.fromParts("package", context.packageName, null),
-    )
-
-    /**
-     * Get intent for opening the battery optimization settings so the user can re-enable it.
-     */
-    fun getBatteryOptSettingsIntent() = Intent(
-        Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS,
     )
 }

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -40,7 +40,6 @@ class Preferences(initialContext: Context) {
         const val PREF_FILENAME_TEMPLATE = "filename_template"
         const val PREF_OUTPUT_FORMAT = "output_format"
         const val PREF_MIN_DURATION = "min_duration"
-        const val PREF_INHIBIT_BATT_OPT = "inhibit_batt_opt"
         private const val PREF_WRITE_METADATA = "write_metadata"
         private const val PREF_RECORD_TELECOM_APPS = "record_telecom_apps"
         private const val PREF_RECORD_DIALING_STATE = "record_dialing_state"

--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -49,7 +49,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
     private lateinit var prefOutputDir: LongClickablePreference
     private lateinit var prefOutputFormat: Preference
     private lateinit var prefMinDuration: Preference
-    private lateinit var prefInhibitBatteryOpt: SwitchPreferenceCompat
     private lateinit var prefShowLauncherIcon: SwitchPreferenceCompat
     private lateinit var prefVersion: LongClickablePreference
     private lateinit var prefMigrateDirectBoot: Preference
@@ -63,10 +62,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
             } else {
                 startActivity(Permissions.getAppInfoIntent(requireContext()))
             }
-        }
-    private val requestInhibitBatteryOpt =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            refreshInhibitBatteryOptState()
         }
     private val requestSafSaveLogs =
         registerForActivityResult(ActivityResultContracts.CreateDocument(Logcat.MIMETYPE)) { uri ->
@@ -110,9 +105,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
         prefMinDuration.onPreferenceClickListener = this
         refreshMinDuration()
 
-        prefInhibitBatteryOpt = findPreference(Preferences.PREF_INHIBIT_BATT_OPT)!!
-        prefInhibitBatteryOpt.onPreferenceChangeListener = this
-
         prefShowLauncherIcon = findPreference(Preferences.PREF_SHOW_LAUNCHER_ICON)!!
         prefShowLauncherIcon.onPreferenceChangeListener = this
         refreshLauncherIcon()
@@ -145,9 +137,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
         super.onStart()
 
         preferenceScreen.sharedPreferences!!.registerOnSharedPreferenceChangeListener(this)
-
-        // Changing the battery state does not cause a reload of the activity
-        refreshInhibitBatteryOptState()
     }
 
     override fun onStop() {
@@ -224,11 +213,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
         categoryDebug.isVisible = prefs.isDebugMode
     }
 
-    private fun refreshInhibitBatteryOptState() {
-        val inhibiting = Permissions.isInhibitingBatteryOpt(requireContext())
-        prefInhibitBatteryOpt.isChecked = inhibiting
-    }
-
     override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
         val context = requireContext()
 
@@ -238,14 +222,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
             } else {
                 // Ask for optional permissions the first time only
                 requestPermissionRequired.launch(Permissions.REQUIRED + Permissions.OPTIONAL)
-            }
-            prefInhibitBatteryOpt -> {
-                if (newValue == true) {
-                    requestInhibitBatteryOpt.launch(
-                        Permissions.getInhibitBatteryOptIntent(requireContext()))
-                } else {
-                    startActivity(Permissions.getBatteryOptSettingsIntent())
-                }
             }
             prefShowLauncherIcon -> {
                 prefs.showLauncherIcon = newValue == true

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_output_dir_desc">اختيار مجلد حفظ التسجيلات ،اضغط من اجل فتح مستعرض مكان الحفظ</string>
     <string name="pref_output_format_name">صيغة حفظ التسجيل</string>
     <string name="pref_output_format_desc">اختيار صيغة التسجيل</string>
-    <string name="pref_inhibit_batt_opt_name"> تعطيل تحسين البطارية</string>
     <string name="pref_version_name">الاصدار</string>
     <string name="pref_header_rules">الارقام المراد تسجيل مكالماتها</string>
     <string name="record_rule_number_contact_summary">الاسم: %s</string>

--- a/app/src/main/res/values-az-rIR/strings.xml
+++ b/app/src/main/res/values-az-rIR/strings.xml
@@ -30,9 +30,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">هر طولده ضبطلری ساخلا.</string>
 
-    <string name="pref_inhibit_batt_opt_name">باتری اوپتیمیزاسیونونو غیرفعال ائت</string>
-    <string name="pref_inhibit_batt_opt_desc">برنامه‌نین سیستم طرفین‌دن دایاندیریلماسی احتیمالینی آزالدیر.</string>
-
     <string name="pref_write_metadata_name">متادیتا فایلی یاز</string>
     <string name="pref_write_metadata_desc">سس فایلینین یانیندا زنگ حاقدا تفصیلاتلی JSON فایل یارات.</string>
 

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -30,9 +30,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">İstənilən uzunluqdakı yazıları saxlayın.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Batareya optimallaşdırmasını deaktiv edin</string>
-    <string name="pref_inhibit_batt_opt_desc">Tətbiqin sistem tərəfindən dayandırılma ehtimalını azaldır.</string>
-
     <string name="pref_write_metadata_name">Metaverilər faylı yaz</string>
     <string name="pref_write_metadata_desc">Səs faylının yanında zəng haqqında təfərrüatları ehtiva edən JSON faylı yaradın.</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Aufnahmeformat</string>
     <string name="pref_output_format_desc">Wähle ein Dateiformat für die Aufnahmen.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Deaktivere die Batterieoptimierung</string>
-    <string name="pref_inhibit_batt_opt_desc">Reduziert die Wahrscheinlichkeit, dass die App vom System beendet wird.</string>
-
     <!-- About "preference" -->
     <string name="pref_version_name">Version</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,9 +15,6 @@
     <string name="pref_output_format_name">Formato de salida</string>
     <string name="pref_output_format_desc">Seleccione un formato de codificación para las grabaciones.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Deshabilitar la optimización de la batería</string>
-    <string name="pref_inhibit_batt_opt_desc">Reduce la posibilidad de que el sistema elimine la aplicación.</string>
-
     <!-- About "preference" -->
     <string name="pref_version_name">Versión</string>
 

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -26,9 +26,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">ضبط‌ها با هر طول را ذخیره کن.</string>
 
-    <string name="pref_inhibit_batt_opt_name">غیرفعال کردن بهینه‌سازی باتری</string>
-    <string name="pref_inhibit_batt_opt_desc">احتمال متوقف شدن برنامه توسط سیستم را کاهش می‌دهد.</string>
-
     <string name="pref_write_metadata_name">نوشتن فایل متادیتا</string>
     <string name="pref_write_metadata_desc">یک فایل JSON حاوی جزئیات تماس در کنار فایل صوتی ایجاد کن.</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -30,9 +30,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">Garder les enregistrements de toutes durées.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Désactiver l\'optimisation de la batterie</string>
-    <string name="pref_inhibit_batt_opt_desc">Réduit les chances que l\'application soit arrêtée par le système.</string>
-
     <string name="pref_write_metadata_name">Écriture fichier metadata</string>
     <string name="pref_write_metadata_desc">Créer un fichier JSON contenant les détails des appels avec le fichier audio.</string>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">आउटपुट स्वरूप</string>
     <string name="pref_output_format_desc">रिकॉर्डिंग के लिए एक एन्कोडिंग प्रारूप चुनें।</string>
 
-    <string name="pref_inhibit_batt_opt_name">बैटरी अनुकूलन अक्षम करें</string>
-    <string name="pref_inhibit_batt_opt_desc">सिस्टम द्वारा ऐप के बंद होने की संभावना कम हो जाती है।</string>
-
     <string name="pref_write_metadata_name">मेटाडेटा फ़ाइल लिखें</string>
     <string name="pref_write_metadata_desc">ऑडियो फ़ाइल के बगल में कॉल के बारे में विवरण वाली एक JSON फ़ाइल बनाएं।</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -25,9 +25,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">Conserva registrazioni di qualsiasi lunghezza.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Disabilita l\'ottimizzazione della batteria</string>
-    <string name="pref_inhibit_batt_opt_desc">Riduce le chance che l\'app sia killata dal sistema.</string>
-
     <string name="pref_write_metadata_name">Scrivi un file con i metadati</string>
     <string name="pref_write_metadata_desc">Crea un file JSON contenente i dettagli sulla chiamata insieme al file audio.</string>
 

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -26,8 +26,6 @@
         <item quantity="other">שמירת הקלטות באורך של %d שניות לפחות.</item>
     </plurals>
     <string name="pref_min_duration_desc_zero">שמירת הקלטות בכל אורך.</string>
-    <string name="pref_inhibit_batt_opt_name">השבתת מיטוב סוללה</string>
-    <string name="pref_inhibit_batt_opt_desc">מפחית את הסיכוי שהיישום יסגר על ידי המערכת.</string>
     <string name="pref_write_metadata_name">כתיבת קובץ מטה-נתונים</string>
     <string name="pref_write_metadata_desc">צור קובץ JSON המכיל פרטים על השיחה ליד קובץ האודיו.</string>
     <string name="pref_record_telecom_apps_name">הקלטת יישומים משולבי טלקום</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -38,8 +38,6 @@
     <string name="pref_output_dir_desc">録音を保存するディレクトリを選択します。 長押しするとファイルマネージャーで開きます。</string>
     <string name="pref_output_format_name">出力フォーマット</string>
     <string name="pref_output_format_desc">録音のエンコード形式を選択します。</string>
-    <string name="pref_inhibit_batt_opt_name">バッテリーの最適化を無効にする</string>
-    <string name="pref_inhibit_batt_opt_desc">アプリがシステムによって強制終了される可能性が低くなります。</string>
     <string name="filename_template_dialog_message">出力ファイル名のカスタム テンプレートを入力します。 変数は中括弧で指定します (例: <annotation type="template">{var}</annotation>)。 フォールバックは角かっこで指定します (例: <annotation type="template">[{contact_name}|Unknown]</annotation>)。  サポートされている変数: <annotation type="supported_vars">PLACEHOLDER</annotation>。 構文の詳細については、 <annotation type="template_docs">ドキュメント</annotation> を参照してください。</string>
     <string name="format_param_dialog_message">[%1$s, %2$s] の範囲の値を入力します。</string>
     <string name="format_param_bitrate_kbps">%s kbps</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Format wyjściowy</string>
     <string name="pref_output_format_desc">Wybierz format kodowania nagrań.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Wyłącz optymalizację baterii</string>
-    <string name="pref_inhibit_batt_opt_desc">Zmniejsza szansę na zabicie aplikacji przez system.</string>
-
     <string name="pref_write_metadata_name">Zapisuj plik metadanych</string>
     <string name="pref_write_metadata_desc">Twórz plik  JSON zawierający szczegóły o połączeniu obok pliku audio.</string>
 

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Formato de Saída</string>
     <string name="pref_output_format_desc">Selecione um formato de codificação para as gravações.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Desativar Otimização de Bateria</string>
-    <string name="pref_inhibit_batt_opt_desc">Reduz a probabilidade de a aplicação ser encerrada pelo sistema.</string>
-
     <string name="pref_write_metadata_name">Escrever Ficheiro de Metadados</string>
     <string name="pref_write_metadata_desc">Crie um ficheiro JSON contendo detalhes sobre a chamada ao lado do ficheiro de áudio.</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -27,9 +27,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">Păstrați înregistrări de orice durată.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Dezactivați optimizarea bateriei</string>
-    <string name="pref_inhibit_batt_opt_desc">Redu șansele ca aplicația să fie oprită de sistem.</string>
-
     <string name="pref_write_metadata_name">Scrieți fișierul cu metadate</string>
     <string name="pref_write_metadata_desc">Creați un fișier JSON care conține detalii despre apel pe lângă fișierul audio.</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Формат записи</string>
     <string name="pref_output_format_desc">Выберите формат записи для звонков.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Отключить оптимизацию батареи.</string>
-    <string name="pref_inhibit_batt_opt_desc">Снижает вероятность того, что приложение будет остановлено системой.</string>
-
     <string name="pref_write_metadata_name">Сохранить файл с метаданными</string>
     <string name="pref_write_metadata_desc">В отдельный JSON файл будут записаны подробные данные о звонке.</string>
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Formát súborov</string>
     <string name="pref_output_format_desc">Vyberte formát kódovania nahrávok.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Zakázať optimalizáciu batérie</string>
-    <string name="pref_inhibit_batt_opt_desc">Znižuje ryziko ukončenia aplikácie systémom</string>
-
     <string name="pref_write_metadata_name">Zapísať meta údaje do súboru</string>
     <string name="pref_write_metadata_desc">V nastavenom priečinku vytvárať aj JSON súbor s podrobnosťami o nahratom hovore.</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Kayıt formatı</string>
     <string name="pref_output_format_desc">Kayıtlar için bir dosya formatı seçin.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Pil optimizasyonunu devre dışı bırak</string>
-    <string name="pref_inhibit_batt_opt_desc">Uygulamanın sistem tarafından durdurulma riskini azaltır.</string>
-
     <string name="pref_write_metadata_name">Metadata dosyası oluştur</string>
     <string name="pref_write_metadata_desc">Ses dosyasının yanında aramayla ilgili ayrıntıları içeren bir JSON dosyası oluşturun.</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Вихідний формат</string>
     <string name="pref_output_format_desc">Виберіть формат кодування записів.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Вимкнути оптимізацію акумулятора</string>
-    <string name="pref_inhibit_batt_opt_desc">Зменшує ймовірність закриття програми системою.</string>
-
     <!-- About "preference" -->
     <string name="pref_version_name">Версія</string>
 

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -11,8 +11,6 @@
     <string name="pref_output_dir_desc">ریکارڈنگز کو ذخیرہ کرنے کے لئے ایک ڈائریکٹری منتخب کریں۔ فائل مینیجر میں کھولنے کے لئے لانگ پریس کریں۔</string>
     <string name="pref_output_format_name">آؤٹپٹ فارمیٹ</string>
     <string name="pref_output_format_desc">ریکارڈنگز کے لئے ایک انکوڈنگ فارمیٹ منتخب کریں۔</string>
-    <string name="pref_inhibit_batt_opt_name">بیٹری انسداد کو غیر فعال کریں</string>
-    <string name="pref_inhibit_batt_opt_desc">سسٹم کے ذریعہ ایپ کو بند کر دینے کی ممکنیت کو کم کرتا ہے۔</string>
     <string name="pref_write_metadata_name">میٹا ڈیٹا فائل لکھیں</string>
     <string name="pref_write_metadata_desc">کال کے بارے میں تفصیلات شامل کرنے والی ایک JSON فائل بنائیں اور اسے آڈیو فائل کے بجائے رکھیں۔</string>
     <string name="pref_version_name">ورژن</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">Định dạng đầu ra</string>
     <string name="pref_output_format_desc">Chọn một định dạng mã hóa cho các bản ghi âm.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Tắt tối ưu hóa pin</string>
-    <string name="pref_inhibit_batt_opt_desc">Giảm khả năng ứng dụng bị hệ thống tắt.</string>
-
     <string name="pref_write_metadata_name">Ghi tệp metadata</string>
     <string name="pref_write_metadata_desc">Tạo một tệp JSON chứa chi tiết về cuộc gọi bên cạnh tệp âm thanh.</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">保存格式</string>
     <string name="pref_output_format_desc">选择录音存储编码格式</string>
 
-    <string name="pref_inhibit_batt_opt_name">禁用电池优化</string>
-    <string name="pref_inhibit_batt_opt_desc">禁用电池优化可以避免软件在后台被杀死</string>
-
     <string name="pref_write_metadata_name">保存元数据文件</string>
     <string name="pref_write_metadata_desc">创建同名 JSON 文件包含通话录音详情</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -18,9 +18,6 @@
     <string name="pref_output_format_name">輸出格式</string>
     <string name="pref_output_format_desc">選擇錄音檔的編碼格式。</string>
 
-    <string name="pref_inhibit_batt_opt_name">停用電池最佳化</string>
-    <string name="pref_inhibit_batt_opt_desc">減少本應用程式被系統終止的可能性。</string>
-
     <string name="pref_write_metadata_name">寫入詮釋資料</string>
     <string name="pref_write_metadata_desc">在音訊檔案旁建立包含通話詳細資料的 JSON 檔案。</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,9 +30,6 @@
     </plurals>
     <string name="pref_min_duration_desc_zero">Keep recordings of any length.</string>
 
-    <string name="pref_inhibit_batt_opt_name">Disable battery optimization</string>
-    <string name="pref_inhibit_batt_opt_desc">Reduces the chance of the app being killed by the system.</string>
-
     <string name="pref_write_metadata_name">Write metadata file</string>
     <string name="pref_write_metadata_desc">Create a JSON file containing details about the call next to the audio file.</string>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -41,13 +41,6 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
-            app:key="inhibit_batt_opt"
-            app:persistent="false"
-            app:title="@string/pref_inhibit_batt_opt_name"
-            app:summary="@string/pref_inhibit_batt_opt_desc"
-            app:iconSpaceReserved="false" />
-
-        <SwitchPreferenceCompat
             app:key="write_metadata"
             app:title="@string/pref_write_metadata_name"
             app:summary="@string/pref_write_metadata_desc"


### PR DESCRIPTION
It never actually did anything. BCR is always permitted to start a foreground service anyway with how the telephony framework binds to `RecorderInCallService`.