### PR TITLE
Remove migration of legacy record rules

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -45,10 +45,6 @@ class RecorderApplication : Application() {
 
         // Move preferences to device-protected storage for direct boot support.
         Preferences.migrateToDeviceProtectedStorage(this)
-
-        // Migrate legacy preferences.
-        val prefs = Preferences(this)
-        prefs.migrateLegacyRules()
     }
 
     companion object {

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
@@ -1,12 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.bcr.rule
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.os.Parcelable
 import android.util.Log
 import com.chiller3.bcr.GroupLookup
@@ -207,128 +206,6 @@ data class RecordRule(
             }
 
             throw IllegalArgumentException("Call does not match any rule")
-        }
-    }
-}
-
-sealed class LegacyRecordRule {
-    abstract val record: Boolean
-
-    private data class AllCalls(override val record: Boolean) : LegacyRecordRule() {
-        companion object {
-            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): AllCalls {
-                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
-
-                return AllCalls(record)
-            }
-        }
-    }
-
-    private data class UnknownCalls(override val record: Boolean) : LegacyRecordRule() {
-        companion object {
-            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): UnknownCalls {
-                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
-
-                return UnknownCalls(record)
-            }
-        }
-    }
-
-    private data class Contact(val lookupKey: String, override val record: Boolean) : LegacyRecordRule() {
-        companion object {
-            private const val PREF_SUFFIX_CONTACT_LOOKUP_KEY = "contact_lookup_key"
-
-            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): Contact {
-                val prefLookupKey = prefix + PREF_SUFFIX_CONTACT_LOOKUP_KEY
-                val contactId = prefs.getString(prefLookupKey, null)
-                    ?: throw IllegalArgumentException("Missing $prefLookupKey")
-                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
-
-                return Contact(contactId, record)
-            }
-        }
-    }
-
-    private data class ContactGroup(
-        val rowId: Long,
-        val sourceId: String?,
-        override val record: Boolean,
-    ) : LegacyRecordRule() {
-        companion object {
-            private const val PREF_SUFFIX_CONTACT_GROUP_ROW_ID = "contact_group_row_id"
-            private const val PREF_SUFFIX_CONTACT_GROUP_SOURCE_ID = "contact_group_source_id"
-
-            fun fromRawPreferences(prefs: SharedPreferences, prefix: String): ContactGroup {
-                val prefRowId = prefix + PREF_SUFFIX_CONTACT_GROUP_ROW_ID
-                val rowId = prefs.getLong(prefRowId, -1)
-                if (rowId == -1L) {
-                    throw IllegalStateException("Missing $prefRowId")
-                }
-
-                val prefSourceId = prefix + PREF_SUFFIX_CONTACT_GROUP_SOURCE_ID
-                val sourceId = prefs.getString(prefSourceId, null)
-
-                val record = prefs.getBoolean(prefix + PREF_SUFFIX_RECORD, false)
-
-                return ContactGroup(rowId, sourceId, record)
-            }
-        }
-    }
-
-    companion object {
-        private val TAG = LegacyRecordRule::class.java.simpleName
-
-        private const val PREF_SUFFIX_TYPE = "type"
-        private const val PREF_SUFFIX_RECORD = "record"
-
-        fun fromRawPreferences(prefs: SharedPreferences, prefix: String): LegacyRecordRule? {
-            // The type was named after the class name, which used to not have the Legacy prefix.
-            val type = prefs.getString(prefix + PREF_SUFFIX_TYPE, null)?.let { "Legacy$it" }
-
-            return when (type) {
-                AllCalls::class.java.simpleName ->
-                    AllCalls.fromRawPreferences(prefs, prefix)
-                UnknownCalls::class.java.simpleName ->
-                    UnknownCalls.fromRawPreferences(prefs, prefix)
-                Contact::class.java.simpleName ->
-                    Contact.fromRawPreferences(prefs, prefix)
-                ContactGroup::class.java.simpleName ->
-                    ContactGroup.fromRawPreferences(prefs, prefix)
-                null -> null
-                else -> {
-                    Log.w(TAG, "Unknown record rule type: $type")
-                    null
-                }
-            }
-        }
-
-        fun convertToModernRules(legacyRules: List<LegacyRecordRule>): List<RecordRule> {
-            val modernRules = mutableListOf<RecordRule>()
-
-            for (legacyRule in legacyRules) {
-                val callNumber = when (legacyRule) {
-                    is AllCalls -> RecordRule.CallNumber.Any
-                    is Contact -> RecordRule.CallNumber.Contact(legacyRule.lookupKey)
-                    is ContactGroup -> RecordRule.CallNumber.ContactGroup(
-                        legacyRule.rowId,
-                        legacyRule.sourceId,
-                    )
-                    is UnknownCalls -> RecordRule.CallNumber.Unknown
-                }
-
-                modernRules.add(RecordRule(
-                    callNumber = callNumber,
-                    callType = RecordRule.CallType.ANY,
-                    simSlot = RecordRule.SimSlot.Any,
-                    action = if (legacyRule.record) {
-                        RecordRule.Action.SAVE
-                    } else {
-                        RecordRule.Action.DISCARD
-                    },
-                ))
-            }
-
-            return modernRules
         }
     }
 }


### PR DESCRIPTION
These migrations have been present since 1.75, which was released more than a year ago.