### PR TITLE
Remove migration of legacy notification channels

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -36,7 +36,7 @@ class Notifications(
         const val CHANNEL_ID_SUCCESS = "success"
         const val CHANNEL_ID_SILENCE = "silence"
 
-        private val LEGACY_CHANNEL_IDS = arrayOf("alerts")
+        private val LEGACY_CHANNEL_IDS = arrayOf<String>()
 
         /** For access to system/internal resource values. */
         private val systemRes = Resources.getSystem()


### PR DESCRIPTION
These migrations have been present since 1.24, which was released more than 3 years ago.