### PR TITLE
Make `{phone_number:E.164}` actually output E.164

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,11 @@ BCR supports customizing the template used for determining the output filenames 
 * `{direction}`: **[Android 10+ only]** For 1-on-1 calls, either `in` or `out` depending on if the call is an incoming or outgoing call. If the call is a conference call, then `conference` is used instead.
 * `{sim_slot}`: **[Android 11+ only]** The SIM slot number for the call (counting from 1). This is only defined for multi-SIM devices that have multiple SIMs active and if BCR is granted the Phone permission.
   * To include the SIM slot even if there's only one active SIM, use `{sim_slot:always}`.
-* `{phone_number}`: The phone number for the call. This is undefined for private calls. Available formatting options:
-  * `{phone_number:E.164}`: Default (same as just `{phone_number}`). Phone number formatted in the international E.164 format (`+<country code><subscriber>`).
-  * `{phone_number:digits_only}`: Phone number with digits only (no `+` or separators).
-  * `{phone_number:formatted}`: Phone number formatted using the country-specific style.
+* `{phone_number}`: The phone number for the call. This is undefined for private calls. The default formatting is unspecified and the number is presented however Android decides to do so. To format with a specific format:
+  * `{phone_number:E.164}`: International E.164 format (`+<country code><subscriber>`).
+  * `{phone_number:digits_only}`: Default unspecified format, except with numeric digits only.
+  * `{phone_number:formatted}`: Country-specific style.
+  * Sometimes, there is not enough information to format the phone number in these specific formats. It's best to specify a fallback to the default format, such as `[{phone_number:E.164}|{phone_number}|]`.
 * `{caller_name}`: The caller ID as provided by CNAP from the carrier.
 * `{contact_name}` The name of the (first) contact associated with the phone number. This is only defined if BCR is granted the Contacts permission.
 * `{call_log_name}`: The name shown in the call log. This may include more information, like the name of the business, if the system dialer performs reverse lookups. This is only defined if BCR is granted the Read Call Logs permission.

--- a/app/src/main/java/com/chiller3/bcr/output/OutputFilenameGenerator.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputFilenameGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -81,8 +81,8 @@ class OutputFilenameGenerator(
 
     private fun formatPhoneNumber(number: PhoneNumber, arg: String?): String? {
         return when (arg) {
-            // Default is already E.164
-            null, "E.164" -> number.toString()
+            null -> number.toString()
+            "E.164" -> number.format(context, PhoneNumber.Format.E_164)
             "digits_only" -> number.format(context, PhoneNumber.Format.DIGITS_ONLY)
             "formatted" -> number.format(context, PhoneNumber.Format.COUNTRY_SPECIFIC)
                 // Don't fail since this isn't the user's fault

--- a/app/src/main/java/com/chiller3/bcr/output/PhoneNumber.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/PhoneNumber.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -17,20 +17,19 @@ data class PhoneNumber(private val number: String) {
     }
 
     fun format(context: Context, format: Format) = when (format) {
+        Format.E_164 -> {
+            val country = getIsoCountryCode(context) ?: return null
+            PhoneNumberUtils.formatNumberToE164(number, country)
+        }
         Format.DIGITS_ONLY -> number.filter { Character.digit(it, 10) != -1 }
         Format.COUNTRY_SPECIFIC -> {
-            val country = getIsoCountryCode(context)
-            if (country == null) {
-                Log.w(TAG, "Failed to detect country")
+            val country = getIsoCountryCode(context) ?: return null
+            val formatted = PhoneNumberUtils.formatNumber(number, country)
+            if (formatted == null) {
+                Log.w(TAG, "Phone number cannot be formatted for country $country")
                 null
             } else {
-                val formatted = PhoneNumberUtils.formatNumber(number, country)
-                if (formatted == null) {
-                    Log.w(TAG, "Phone number cannot be formatted for country $country")
-                    null
-                } else {
-                    formatted
-                }
+                formatted
             }
         }
     }
@@ -57,6 +56,7 @@ data class PhoneNumber(private val number: String) {
                 result = Locale.getDefault().country
             }
             if (result.isNullOrEmpty()) {
+                Log.w(TAG, "Failed to detect country")
                 return null
             }
             return result.uppercase()
@@ -64,6 +64,7 @@ data class PhoneNumber(private val number: String) {
     }
 
     enum class Format {
+        E_164,
         DIGITS_ONLY,
         COUNTRY_SPECIFIC,
     }


### PR DESCRIPTION
Previously, it was defined to be the same as `{phone_number}`. However, Android's default formatting is not guaranteed to be E.164.