### PR TITLE
Notify when a file could not be moved to the output directory

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -385,18 +385,48 @@ class Notifications(
         vibrateIfEnabled(CHANNEL_ID_SILENCE)
     }
 
+    /** Send a file move failure alert notification. */
+    fun notifyMoveFailure(errorMsg: String?) {
+        val notificationId = prefs.nextNotificationId
+
+        val notification = Notification.Builder(context, CHANNEL_ID_FAILURE).run {
+            setContentTitle(context.getString(R.string.notification_move_failed))
+
+            setContentText(buildString {
+                append(context.getString(R.string.notification_move_error))
+
+                errorMsg?.trim()?.let {
+                    append("\n\n")
+                    append(it)
+                }
+            })
+            style = Notification.BigTextStyle()
+
+            setSmallIcon(R.drawable.ic_launcher_quick_settings)
+
+            build()
+        }
+
+        notificationManager.notify(notificationId, notification)
+    }
+
     /** Send a direct boot file migration failure alert notification. */
     fun notifyMigrationFailure(errorMsg: String?) {
         val notificationId = prefs.nextNotificationId
 
         val notification = Notification.Builder(context, CHANNEL_ID_FAILURE).run {
-            val text = errorMsg?.trim() ?: ""
-
             setContentTitle(context.getString(R.string.notification_direct_boot_migration_failed))
-            if (text.isNotBlank()) {
-                setContentText(text)
-                style = Notification.BigTextStyle()
-            }
+
+            setContentText(buildString {
+                append(context.getString(R.string.notification_direct_boot_migration_error))
+
+                errorMsg?.trim()?.let {
+                    append("\n\n")
+                    append(it)
+                }
+            })
+            style = Notification.BigTextStyle()
+
             setSmallIcon(R.drawable.ic_launcher_quick_settings)
 
             build()

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -31,7 +31,11 @@ class RecorderApplication : Application() {
                 try {
                     Logcat.dump(logcatFile.uri.toFile())
                 } finally {
-                    dirUtils.tryMoveToOutputDir(logcatFile, logcatPath, "text/plain")
+                    try {
+                        dirUtils.moveToOutputDir(logcatFile, logcatPath, "text/plain")
+                    } catch (_: Exception) {
+                        // Ignore.
+                    }
                 }
             } finally {
                 oldCrashHandler?.uncaughtException(t, e)

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -471,6 +471,12 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
         Log.i(TAG, "Recording completed: ${thread.threadIdCompat}: ${file?.redacted}: $status")
         handler.post {
             onRecorderExited(thread)
+
+            val firstMoveError = file?.moveError
+                ?: additionalFiles.firstNotNullOfOrNull { it.moveError }
+            if (firstMoveError != null) {
+                notifications.notifyMoveFailure(firstMoveError.localizedMessage)
+            }
 
             when (status) {
                 RecorderThread.Status.Succeeded -> {

--- a/app/src/main/java/com/chiller3/bcr/output/OutputDirUtils.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputDirUtils.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -243,13 +243,13 @@ class OutputDirUtils(private val context: Context, private val redactor: Redacto
     /**
      * Try to move [sourceFile] to the user output directory at [path].
      *
-     * @return Whether the user output directory is set and the file was successfully moved
+     * @return The new file, which may be the same as [sourceFile] if moving was not needed.
      */
-    fun tryMoveToOutputDir(
+    fun moveToOutputDir(
         sourceFile: DocumentFile,
         path: List<String>,
         mimeType: String,
-    ): DocumentFile? {
+    ): DocumentFile {
         val userDir = prefs.outputDirOrDefault.toDocumentFile(context)
         val redactedSource = redactor.redact(sourceFile.uri)
 
@@ -273,7 +273,7 @@ class OutputDirUtils(private val context: Context, private val redactor: Redacto
             targetFile
         } catch (e: Exception) {
             Log.e(TAG, "Failed to move $redactedSource to $userDir", e)
-            null
+            throw e
         }
     }
 

--- a/app/src/main/java/com/chiller3/bcr/output/OutputFile.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputFile.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022-2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2022-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -29,6 +29,9 @@ data class OutputFile(
      * meaningful path.
      */
     val path: String,
+
+    /** Error when moving file to the desired output directory. */
+    val moveError: Exception?,
 
     /** MIME type of [uri]'s contents. */
     val mimeType: String,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,8 @@
     <string name="notification_recording_on_hold">Call on hold</string>
     <string name="notification_recording_failed">Failed to record call</string>
     <string name="notification_recording_succeeded">Successfully recorded call</string>
+    <string name="notification_move_failed">Failed to move recording</string>
+    <string name="notification_move_error">One or more files could not be moved to the selected output directory. They are still present in the default output directory.</string>
     <string name="notification_message_delete_at_end">The recording will be deleted at the end of the call. Tap Restore to keep the recording.</string>
     <plurals name="notification_message_delete_at_end_too_short">
         <item quantity="one">The recording will be deleted at the end of the call if it is shorter than %d second. Tap Restore to keep the recording.</item>


### PR DESCRIPTION
While BCR already shows the full path to the file in the recording completion notifications, it's still easy to miss if you're not reading carefully. The most common way for moving to fail is if the output directory is deleted and recreated. Android will not automatically grant permissions to the newly recreated directory.

Fixes: #797