### PR TITLE
Revert "Add new debugOpt build type for testing R8"

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,23 +150,7 @@ android {
         }
     }
     buildTypes {
-        getByName("debug") {
-            buildConfigField("boolean", "FORCE_DEBUG_MODE", "true")
-        }
-
-        create("debugOpt") {
-            buildConfigField("boolean", "FORCE_DEBUG_MODE", "true")
-
-            isMinifyEnabled = true
-            isShrinkResources = true
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-
-            signingConfig = signingConfigs.getByName("debug")
-        }
-
         getByName("release") {
-            buildConfigField("boolean", "FORCE_DEBUG_MODE", "false")
-
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -133,7 +133,7 @@ class Preferences(initialContext: Context) {
     /** Whether to show debug preferences and enable creation of debug logs for all calls. */
     @Suppress("KotlinConstantConditions", "SimplifyBooleanWithConstants")
     var isDebugMode: Boolean
-        get() = BuildConfig.FORCE_DEBUG_MODE || prefs.getBoolean(PREF_DEBUG_MODE, false)
+        get() = BuildConfig.DEBUG || prefs.getBoolean(PREF_DEBUG_MODE, false)
         set(enabled) = prefs.edit { putBoolean(PREF_DEBUG_MODE, enabled) }
 
     /** Whether to output to direct boot directories even if the device has been unlocked once. */


### PR DESCRIPTION
This never ended up being useful.

This reverts commit 79a38a8db9afa9c99c6ab32ff516bd69e0a4e8ff.