### PR TITLE
Block file retention feature when {date} is in the template twice

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/output/OutputFilenameGenerator.kt
+++ b/app/src/main/java/com/chiller3/bcr/output/OutputFilenameGenerator.kt
@@ -41,7 +41,7 @@ class OutputFilenameGenerator(
     // Templates
     private val filenameTemplate = Preferences(context).filenameTemplate
         ?: Preferences.DEFAULT_FILENAME_TEMPLATE
-    private val dateVarLocations = filenameTemplate.findVariableRef(DATE_VAR)?.second
+    private val dateVarLocations = filenameTemplate.findVariableRef(DATE_VAR, true)?.second
 
     // Timestamps
     private var formatter = FORMATTER

--- a/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryBottomSheetFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryBottomSheetFragment.kt
@@ -116,7 +116,7 @@ class OutputDirectoryBottomSheetFragment : BottomSheetDialogFragment() {
     private fun refreshOutputRetention() {
         // Disable retention options if the template makes it impossible for the feature to work
         val template = prefs.filenameTemplate ?: Preferences.DEFAULT_FILENAME_TEMPLATE
-        val locations = template.findVariableRef(OutputFilenameGenerator.DATE_VAR)
+        val locations = template.findVariableRef(OutputFilenameGenerator.DATE_VAR, true)
         val retentionUsable = locations != null &&
                 locations.second != setOf(Template.VariableRefLocation.Arbitrary)
 

--- a/app/src/main/java/com/chiller3/bcr/template/Template.kt
+++ b/app/src/main/java/com/chiller3/bcr/template/Template.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -411,12 +411,22 @@ class Template(template: String) {
      * Find the first reference to the specified variable and the set of string literal prefixes
      * that can be used to potentially find it inside a string produced by the template.
      *
+     * @param unique Whether to only return a result if there is a single occurrence of the variable
+     * reference
+     *
      * @return the variable name, argument, and the locations where its value could start in a
      * output string.
      */
-    fun findVariableRef(name: String): Pair<VariableRef, Set<VariableRefLocation>>? {
+    fun findVariableRef(
+        name: String,
+        unique: Boolean,
+    ): Pair<VariableRef, Set<VariableRefLocation>>? {
         val (varRef, prefixes) = findVariableRefInternal(ast, name)
         if (varRef == null) {
+            return null
+        }
+
+        if (unique && findAllVariableRefs().count { it.name == name } > 1) {
             return null
         }
 

--- a/app/src/test/java/com/chiller3/bcr/template/TemplateTest.kt
+++ b/app/src/test/java/com/chiller3/bcr/template/TemplateTest.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -340,37 +340,48 @@ class TemplateTest {
         assertEquals(
             Pair(
                 Template.VariableRef("var", null),
-                setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
+                setOf(Template.VariableRefLocation.AfterPrefix("", true)),
             ),
-            Template("foo{var}").findVariableRef("var"),
+            Template("{var}{var}").findVariableRef("var", false),
+        )
+        assertEquals(
+            null,
+            Template("{var}{var}").findVariableRef("var", true),
         )
         assertEquals(
             Pair(
                 Template.VariableRef("var", null),
                 setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
             ),
-            Template("[]foo{var}").findVariableRef("var"),
+            Template("foo{var}").findVariableRef("var", true),
         )
         assertEquals(
             Pair(
                 Template.VariableRef("var", null),
                 setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
             ),
-            Template("foo[]{var}").findVariableRef("var"),
+            Template("[]foo{var}").findVariableRef("var", true),
+        )
+        assertEquals(
+            Pair(
+                Template.VariableRef("var", null),
+                setOf(Template.VariableRefLocation.AfterPrefix("foo", true)),
+            ),
+            Template("foo[]{var}").findVariableRef("var", true),
         )
         assertEquals(
             Pair(
                 Template.VariableRef("var", "arg"),
                 setOf(Template.VariableRefLocation.AfterPrefix("", true)),
             ),
-            Template("{var:arg}").findVariableRef("var"),
+            Template("{var:arg}").findVariableRef("var", true),
         )
         assertEquals(
             Pair(
                 Template.VariableRef("date", null),
                 setOf(Template.VariableRefLocation.AfterPrefix("", true)),
             ),
-            Preferences.DEFAULT_FILENAME_TEMPLATE.findVariableRef("date"),
+            Preferences.DEFAULT_FILENAME_TEMPLATE.findVariableRef("date", true),
         )
     }
 


### PR DESCRIPTION
The feature only works if there is a single instance `{date}`. Allowing it to run anyway could result in unexpected file deletion.