### PR TITLE
Allow making the completion notification open the output directory

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,10 +21,12 @@
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"
+        tools:ignore="ForegroundServicesPolicy" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.READ_CALL_LOG" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG"
+        tools:ignore="SmsAndCallLogPolicy" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -254,6 +254,12 @@ class Notifications(
                 // It is not possible to grant access to SAF URIs to other applications
                 val wrappedUri = RecorderProvider.fromOrigUri(file.uri)
 
+                val openDirIntent = PendingIntent.getActivity(
+                    context,
+                    0,
+                    prefs.outputDirOrDefaultIntent,
+                    PendingIntent.FLAG_IMMUTABLE,
+                )
                 val openIntent = PendingIntent.getActivity(
                     context,
                     0,
@@ -305,10 +311,13 @@ class Notifications(
                     deleteIntent,
                 ).build())
 
-                // Clicking on the notification behaves like the open action, except the
-                // notification gets dismissed. The open and share actions do not dismiss the
-                // notification.
-                setContentIntent(openIntent)
+                // Unlike the notification action buttons, clicking on the notification itself will
+                // cause it to be dismissed.
+                if (prefs.notificationOpenDir) {
+                    setContentIntent(openDirIntent)
+                } else {
+                    setContentIntent(openIntent)
+                }
                 setAutoCancel(true)
             }
 

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -42,6 +42,7 @@ class Preferences(initialContext: Context) {
         private const val PREF_WRITE_METADATA = "write_metadata"
         private const val PREF_RECORD_TELECOM_APPS = "record_telecom_apps"
         private const val PREF_RECORD_DIALING_STATE = "record_dialing_state"
+        private const val PREF_NOTIFICATION_OPEN_DIR = "notification_open_dir"
         const val PREF_SHOW_LAUNCHER_ICON = "show_launcher_icon"
         const val PREF_VERSION = "version"
         private const val PREF_FORCE_DIRECT_BOOT = "force_direct_boot"
@@ -381,6 +382,11 @@ class Preferences(initialContext: Context) {
     var recordDialingState: Boolean
         get() = prefs.getBoolean(PREF_RECORD_DIALING_STATE, false)
         set(enabled) = prefs.edit { putBoolean(PREF_RECORD_DIALING_STATE, enabled) }
+
+    /** Whether to open the directory instead of the file on completion notifications. */
+    var notificationOpenDir: Boolean
+        get() = prefs.getBoolean(PREF_NOTIFICATION_OPEN_DIR, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_NOTIFICATION_OPEN_DIR, enabled) }
 
     /**
      * The [ComponentName] for the [SettingsActivity] alias.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,9 @@
     <string name="pref_record_dialing_state_name">Record calls before connection</string>
     <string name="pref_record_dialing_state_desc">For outgoing calls, start recording as soon as dialing begins instead of waiting until the call connects.</string>
 
+    <string name="pref_notification_open_dir_name">Open directory from notification</string>
+    <string name="pref_notification_open_dir_desc">Open the output directory instead of the recording file when tapping on the recording completed notification.</string>
+
     <string name="pref_show_launcher_icon_name">Show launcher icon</string>
     <string name="pref_show_launcher_icon_desc">When the launcher icon is hidden, dial <b>*#*#BCR#*#*</b> to open the app.</string>
 

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -59,6 +59,12 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
+            app:key="notification_open_dir"
+            app:title="@string/pref_notification_open_dir_name"
+            app:summary="@string/pref_notification_open_dir_desc"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
             app:key="show_launcher_icon"
             app:persistent="false"
             app:title="@string/pref_show_launcher_icon_name"


### PR DESCRIPTION
The new toggle only changes what happens when tapping the main area of the notification. The Open, Share, and Delete buttons still always act on the files.

Issue: #794