### PR TITLE
Ensure valid default output directory or fallback to internal storage

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -1,3 +1,4 @@
+ 
 /*
  * SPDX-FileCopyrightText: 2022-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
@@ -160,7 +161,13 @@ class Preferences(initialContext: Context) {
     val defaultOutputDir: File = if (isDirectBoot) {
         directBootInProgressDir
     } else {
-        context.getExternalFilesDir(null)!!
+        try {
+            context.getExternalFilesDir(null)?.let { extDir ->
+                if (extDir.exists() || extDir.mkdirs()) extDir else null
+            } ?: context.filesDir
+        } catch (e: Exception) {
+            context.filesDir
+        }
     }
 
     /**


### PR DESCRIPTION
getExternalFilesDir can throw IllegalStateException on Android 16 if external storage is not available. Fall back to internal storage.