### PR TITLE
Add option to start recordings in the paused state

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -22,6 +22,7 @@ import com.chiller3.bcr.extension.safTreeToDocument
 import com.chiller3.bcr.format.AudioSource
 import com.chiller3.bcr.format.Format
 import com.chiller3.bcr.output.Retention
+import com.chiller3.bcr.rule.LegacyRecordRule
 import com.chiller3.bcr.rule.RecordRule
 import com.chiller3.bcr.settings.SettingsActivity
 import com.chiller3.bcr.template.Template
@@ -77,7 +78,7 @@ class Preferences(initialContext: Context) {
                 callNumber = RecordRule.CallNumber.Any,
                 callType = RecordRule.CallType.ANY,
                 simSlot = RecordRule.SimSlot.Any,
-                action = RecordRule.Action.SAVE,
+                action = RecordRule.Action.Save(initialState = RecordRule.InitialState.RECORDING),
             ),
         )
 
@@ -137,7 +138,6 @@ class Preferences(initialContext: Context) {
     }
 
     /** Whether to show debug preferences and enable creation of debug logs for all calls. */
-    @Suppress("KotlinConstantConditions", "SimplifyBooleanWithConstants")
     var isDebugMode: Boolean
         get() = BuildConfig.DEBUG || prefs.getBoolean(PREF_DEBUG_MODE, false)
         set(enabled) = prefs.edit { putBoolean(PREF_DEBUG_MODE, enabled) }
@@ -291,15 +291,29 @@ class Preferences(initialContext: Context) {
         get() = prefs.getBoolean(PREF_CALL_RECORDING, false)
         set(enabled) = prefs.edit { putBoolean(PREF_CALL_RECORDING, enabled) }
 
-    /** List of rules to determine which action to take for a specific call. */
-    var recordRules: List<RecordRule>?
-        get() = prefs.getString(PREF_RECORD_RULES, null)?.let { JSON_FORMAT.decodeFromString(it) }
+    /** Raw JSON of the record rules for migration. */
+    private var rawRecordRules: String?
+        get() = prefs.getString(PREF_RECORD_RULES, null)
         set(rules) = prefs.edit {
             if (rules == null) {
                 remove(PREF_RECORD_RULES)
             } else {
-                putString(PREF_RECORD_RULES, JSON_FORMAT.encodeToString(rules))
+                putString(PREF_RECORD_RULES, rules)
             }
+        }
+
+    /** List of rules to determine which action to take for a specific call. */
+    var recordRules: List<RecordRule>?
+        get() = rawRecordRules?.let {
+            try {
+                JSON_FORMAT.decodeFromString(it)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Ignoring invalid record rules: $it", e)
+                null
+            }
+        }
+        set(rules) {
+            rawRecordRules = JSON_FORMAT.encodeToString(rules)
         }
 
     /**
@@ -477,6 +491,19 @@ class Preferences(initialContext: Context) {
             }
 
             prefs.edit { remove(PREF_FORMAT_STEREO) }
+        }
+    }
+
+    /** Can be removed starting with BCR 2.19. */
+    fun migrateRecordRules() {
+        val rawRecordRules = rawRecordRules ?: return
+
+        try {
+            val legacyRules = JSON_FORMAT.decodeFromString<List<LegacyRecordRule>>(rawRecordRules)
+
+            recordRules = legacyRules.map { it.toRecordRule() }
+        } catch (_: IllegalArgumentException) {
+            // Already migrated.
         }
     }
 }

--- a/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderApplication.kt
@@ -50,6 +50,7 @@ class RecorderApplication : Application() {
         val prefs = Preferences(this)
         prefs.migrateTemplate()
         prefs.migrateAudioSource()
+        prefs.migrateRecordRules()
     }
 
     companion object {

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -210,16 +210,16 @@ class RecorderThread(
             RecordRule.evaluate(context, rules, numbers, metadata.direction, metadata.simSlot)
         } catch (e: Exception) {
             Log.w(tag, "Failed to evaluate record rules", e)
-            // Err on the side of caution
-            RecordRule.Action.SAVE
+            // Err on the side of caution.
+            RecordRule.Action.Save(initialState = RecordRule.InitialState.RECORDING)
         }
 
         Log.i(tag, "Record rule action: $action")
 
-        val keep = when (action) {
-            RecordRule.Action.SAVE -> true
-            RecordRule.Action.DISCARD -> false
-            RecordRule.Action.IGNORE -> {
+        val (keep, initialState) = when (action) {
+            is RecordRule.Action.Save -> true to action.initialState
+            is RecordRule.Action.Discard -> false to action.initialState
+            RecordRule.Action.Ignore -> {
                 Log.i(tag, "Cancelling due to record rules")
                 cancel()
                 return
@@ -238,6 +238,8 @@ class RecorderThread(
                 KeepState.DISCARD
             },
         )
+
+        isPaused = initialState == RecordRule.InitialState.PAUSED
 
         listener.onRecordingStateChanged(this)
     }
@@ -673,7 +675,7 @@ class RecorderThread(
         var numFramesTotal = 0L
         var numFramesEncoded = 0L
         var bufferOverruns = 0
-        var wasEverPaused = false
+        var wasEverPaused = isPaused
         var wasEverHolding = false
         var wasReadSamplesError = false
         var wasPureSilence = true

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRule.kt
@@ -17,6 +17,38 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+// We have no good way to deserialize LegacyAction into Action:
+// https://github.com/Kotlin/kotlinx.serialization/issues/2460
+// https://github.com/Kotlin/kotlinx.serialization/issues/2463
+@Parcelize
+@Serializable
+data class LegacyRecordRule(
+    @SerialName("call_number")
+    val callNumber: RecordRule.CallNumber,
+    @SerialName("call_type")
+    val callType: RecordRule.CallType,
+    @SerialName("sim_slot")
+    val simSlot: RecordRule.SimSlot,
+    @SerialName("action")
+    val legacyAction: LegacyAction,
+) : Parcelable {
+    @Parcelize
+    @Serializable
+    enum class LegacyAction : Parcelable {
+        SAVE,
+        DISCARD,
+        IGNORE;
+
+        fun toAction(): RecordRule.Action = when (this) {
+            SAVE -> RecordRule.Action.Save(initialState = RecordRule.InitialState.RECORDING)
+            DISCARD -> RecordRule.Action.Discard(initialState = RecordRule.InitialState.RECORDING)
+            IGNORE -> RecordRule.Action.Ignore
+        }
+    }
+
+    fun toRecordRule() = RecordRule(callNumber, callType, simSlot, legacyAction.toAction())
+}
+
 /**
  * A rule specifies several conditions, which are ANDed together, and if a call matches, then the
  * specified action is taken.
@@ -131,24 +163,40 @@ data class RecordRule(
 
     @Parcelize
     @Serializable
-    enum class Action : Parcelable {
+    enum class InitialState : Parcelable {
+        RECORDING,
+        PAUSED,
+    }
+
+    @Parcelize
+    @Serializable
+    sealed interface Action : Parcelable {
         /**
-         * Save the recording when the call ends unless the user chooses to delete it during the call
-         * via the notification.
+         * Save the recording when the call ends unless the user chooses to delete it during the
+         * call via the notification.
          */
-        SAVE,
+        @Parcelize
+        @Serializable
+        @SerialName("save")
+        data class Save(val initialState: InitialState) : Action
 
         /**
          * Delete the recording when the call ends unless the user chooses to preserve it during the
          * call via the notification.
          */
-        DISCARD,
+        @Parcelize
+        @Serializable
+        @SerialName("discard")
+        data class Discard(val initialState: InitialState) : Action
 
         /**
-         * Completely ignore the call. [com.chiller3.bcr.RecorderThread] will exit without writing any
-         * output files. It is not possible to start a recording later for a matching call.
+         * Completely ignore the call. [com.chiller3.bcr.RecorderThread] will exit without writing
+         * any output files. It is not possible to start a recording later for a matching call.
          */
-        IGNORE,
+        @Parcelize
+        @Serializable
+        @SerialName("ignore")
+        data object Ignore : Action
     }
 
     companion object {

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRuleEditorBottomSheet.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRuleEditorBottomSheet.kt
@@ -62,6 +62,9 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
     private var chipIdActionDiscard: Int = -1
     private var chipIdActionIgnore: Int = -1
 
+    private var chipIdInitialStateRecording: Int = -1
+    private var chipIdInitialStatePaused: Int = -1
+
     private var postPermissionAction: PostPermissionAction? = null
 
     private val requestPermission =
@@ -138,17 +141,21 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
         addCallTypeChips(inflater)
         addSimSlotChips(inflater)
         addActionChips(inflater)
+        addInitialStateChips(inflater)
 
         binding.callNumberGroup.setOnCheckedStateChangeListener(this)
         binding.callTypeGroup.setOnCheckedStateChangeListener(this)
         binding.simSlotGroup.setOnCheckedStateChangeListener(this)
         binding.actionGroup.setOnCheckedStateChangeListener(this)
+        binding.initialStateGroup.setOnCheckedStateChangeListener(this)
 
         refreshCallNumber()
         refreshCallType()
         refreshSimSlot()
         refreshAction()
         refreshActionDescription()
+        refreshInitialState()
+        refreshInitialStateDescription()
 
         // Conditions are not editable for the default rule.
         binding.callNumberLayout.isVisible = !isDefault
@@ -312,6 +319,16 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
         chipIdActionIgnore = chipBinding.root.id
     }
 
+    private fun addInitialStateChips(inflater: LayoutInflater) {
+        var chipBinding = addChip(inflater, binding.initialStateGroup)
+        chipBinding.root.setText(R.string.record_rule_initial_state_recording_chip)
+        chipIdInitialStateRecording = chipBinding.root.id
+
+        chipBinding = addChip(inflater, binding.initialStateGroup)
+        chipBinding.root.setText(R.string.record_rule_initial_state_paused_chip)
+        chipIdInitialStatePaused = chipBinding.root.id
+    }
+
     private fun initContactOrGroup() {
         when (val callNumber = recordRule.callNumber) {
             RecordRule.CallNumber.Any -> {}
@@ -390,9 +407,9 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
 
     private fun refreshAction() {
         val chipId = when (recordRule.action) {
-            RecordRule.Action.SAVE -> chipIdActionSave
-            RecordRule.Action.DISCARD -> chipIdActionDiscard
-            RecordRule.Action.IGNORE -> chipIdActionIgnore
+            is RecordRule.Action.Save -> chipIdActionSave
+            is RecordRule.Action.Discard -> chipIdActionDiscard
+            is RecordRule.Action.Ignore -> chipIdActionIgnore
         }
 
         binding.actionGroup.check(chipId)
@@ -400,12 +417,47 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
 
     private fun refreshActionDescription() {
         val descriptionId = when (recordRule.action) {
-            RecordRule.Action.SAVE -> R.string.record_rule_action_save_desc
-            RecordRule.Action.DISCARD -> R.string.record_rule_action_discard_desc
-            RecordRule.Action.IGNORE -> R.string.record_rule_action_ignore_desc
+            is RecordRule.Action.Save -> R.string.record_rule_action_save_desc
+            is RecordRule.Action.Discard -> R.string.record_rule_action_discard_desc
+            is RecordRule.Action.Ignore -> R.string.record_rule_action_ignore_desc
         }
 
         binding.actionDesc.setText(descriptionId)
+    }
+
+    private fun refreshInitialState() {
+        val initialState = when (val action = recordRule.action) {
+            is RecordRule.Action.Save -> action.initialState
+            is RecordRule.Action.Discard -> action.initialState
+            is RecordRule.Action.Ignore -> {
+                binding.initialStateLayout.isVisible = false
+                return
+            }
+        }
+
+        binding.initialStateLayout.isVisible = true
+
+        val chipId = when (initialState) {
+            RecordRule.InitialState.RECORDING -> chipIdInitialStateRecording
+            RecordRule.InitialState.PAUSED -> chipIdInitialStatePaused
+        }
+
+        binding.initialStateGroup.check(chipId)
+    }
+
+    private fun refreshInitialStateDescription() {
+        val initialState = when (val action = recordRule.action) {
+            is RecordRule.Action.Save -> action.initialState
+            is RecordRule.Action.Discard -> action.initialState
+            RecordRule.Action.Ignore -> return
+        }
+
+        val descriptionId = when (initialState) {
+            RecordRule.InitialState.RECORDING -> R.string.record_rule_initial_state_recording_desc
+            RecordRule.InitialState.PAUSED -> R.string.record_rule_initial_state_paused_desc
+        }
+
+        binding.initialStateDesc.setText(descriptionId)
     }
 
     override fun onCheckedChanged(group: ChipGroup, checkedIds: MutableList<Int>) {
@@ -459,16 +511,41 @@ class RecordRuleEditorBottomSheet : BottomSheetDialogFragment(),
                 recordRule = recordRule.copy(simSlot = simSlot)
             }
             binding.actionGroup -> {
+                val initialState = when (val action = recordRule.action) {
+                    is RecordRule.Action.Save -> action.initialState
+                    is RecordRule.Action.Discard -> action.initialState
+                    RecordRule.Action.Ignore -> RecordRule.InitialState.RECORDING
+                }
+
                 val action = when (checkedIds.first()) {
-                    chipIdActionSave -> RecordRule.Action.SAVE
-                    chipIdActionDiscard -> RecordRule.Action.DISCARD
-                    chipIdActionIgnore -> RecordRule.Action.IGNORE
+                    chipIdActionSave -> RecordRule.Action.Save(initialState = initialState)
+                    chipIdActionDiscard -> RecordRule.Action.Discard(initialState = initialState)
+                    chipIdActionIgnore -> RecordRule.Action.Ignore
                     else -> throw IllegalStateException("Invalid action chip ID")
                 }
 
                 recordRule = recordRule.copy(action = action)
 
                 refreshActionDescription()
+                refreshInitialState()
+                refreshInitialStateDescription()
+            }
+            binding.initialStateGroup -> {
+                val initialState = when (checkedIds.first()) {
+                    chipIdInitialStateRecording -> RecordRule.InitialState.RECORDING
+                    chipIdInitialStatePaused -> RecordRule.InitialState.PAUSED
+                    else -> throw IllegalStateException("Invalid initial state chip ID")
+                }
+
+                val action = when (val action = recordRule.action) {
+                    is RecordRule.Action.Save -> action.copy(initialState = initialState)
+                    is RecordRule.Action.Discard -> action.copy(initialState = initialState)
+                    RecordRule.Action.Ignore -> action
+                }
+
+                recordRule = recordRule.copy(action = action)
+
+                refreshInitialStateDescription()
             }
         }
     }

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesAdapter.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -191,11 +191,27 @@ internal class RecordRulesAdapter(
             }
 
             val actionMsgId = when (rule.action) {
-                RecordRule.Action.SAVE -> R.string.record_rule_action_save_summary
-                RecordRule.Action.DISCARD -> R.string.record_rule_action_discard_summary
-                RecordRule.Action.IGNORE -> R.string.record_rule_action_ignore_summary
+                is RecordRule.Action.Save -> R.string.record_rule_action_save_summary
+                is RecordRule.Action.Discard -> R.string.record_rule_action_discard_summary
+                is RecordRule.Action.Ignore -> R.string.record_rule_action_ignore_summary
             }
             append(context.getString(actionMsgId))
+
+            val initialState = when (val action = rule.action) {
+                is RecordRule.Action.Save -> action.initialState
+                is RecordRule.Action.Discard -> action.initialState
+                RecordRule.Action.Ignore -> null
+            }
+            if (initialState != null) {
+                val initialStateResId = when (initialState) {
+                    RecordRule.InitialState.RECORDING ->
+                        R.string.record_rule_initial_state_recording_summary
+                    RecordRule.InitialState.PAUSED ->
+                        R.string.record_rule_initial_state_paused_summary
+                }
+                append('\n')
+                append(context.getString(initialStateResId))
+            }
         }
     }
 

--- a/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/rule/RecordRulesFragment.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -117,7 +117,7 @@ class RecordRulesFragment : PreferenceBaseFragment(), Preference.OnPreferenceCli
                     callNumber = RecordRule.CallNumber.Any,
                     callType = RecordRule.CallType.ANY,
                     simSlot = RecordRule.SimSlot.Any,
-                    action = RecordRule.Action.SAVE,
+                    action = RecordRule.Action.Save(initialState = RecordRule.InitialState.RECORDING),
                 )
 
                 RecordRuleEditorBottomSheet.newInstance(-1, newRule, false)

--- a/app/src/main/res/layout/record_rule_editor_bottom_sheet.xml
+++ b/app/src/main/res/layout/record_rule_editor_bottom_sheet.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
     SPDX-License-Identifier: GPL-3.0-only
 -->
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
@@ -122,5 +122,34 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/bottom_sheet_title_margin_bottom"
             android:textAlignment="center" />
+
+        <LinearLayout
+            android:id="@+id/initial_state_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/bottom_sheet_section_separation"
+                android:text="@string/record_rule_initial_state_title"
+                android:textAppearance="?attr/textAppearanceHeadline6" />
+
+            <com.chiller3.bcr.view.ChipGroupCentered
+                android:id="@+id/initial_state_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/bottom_sheet_title_margin_bottom"
+                app:selectionRequired="true"
+                app:singleSelection="true" />
+
+            <TextView
+                android:id="@+id/initial_state_desc"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/bottom_sheet_title_margin_bottom"
+                android:textAlignment="center" />
+        </LinearLayout>
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -111,6 +111,14 @@
     <string name="record_rule_action_discard_summary">Aktion: Aufnahme verwerfen</string>
     <string name="record_rule_action_ignore_summary">Aktion: Anruf ignorieren</string>
 
+    <string name="record_rule_initial_state_title">Initial state</string>
+    <string name="record_rule_initial_state_recording_chip">Recording</string>
+    <string name="record_rule_initial_state_paused_chip">Paused</string>
+    <string name="record_rule_initial_state_recording_desc">The recording will begin immediately when the call connects.</string>
+    <string name="record_rule_initial_state_paused_desc">The recording will be paused when the call connects. Audio will not be recorded until the recording is resumed via the notification.</string>
+    <string name="record_rule_initial_state_recording_summary">Initial state: Record immediately</string>
+    <string name="record_rule_initial_state_paused_summary">Initial state: Paused until manually resumed</string>
+
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Verzeichnis ändern</string>
     <string name="output_dir_bottom_sheet_filename_template">Dateinamenvorlage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,13 +144,28 @@
     <!-- Description shown for this action in the rule editor. The text can be as verbose as necessary. -->
     <string name="record_rule_action_discard_desc">Discard the recording at the end of the call. The recording can be preserved via the notification shown during a call.</string>
     <!-- Description shown for this action in the rule editor. The text can be as verbose as necessary. -->
-    <string name="record_rule_action_ignore_desc">Completely ignore the call. The call will not be recorded and it is not possible to start the recording during the call.</string>
-    <!-- Summary shown in the record rules list descriptions. This should include a "Action: " prefix for visual consistency. -->
+    <string name="record_rule_action_ignore_desc">Completely ignore the call. The call will not be recorded, and it is not possible to start the recording during the call.</string>
+    <!-- Summary shown in the record rules list descriptions. This should include an "Action: " prefix for visual consistency. -->
     <string name="record_rule_action_save_summary">Action: Save recording</string>
-    <!-- Summary shown in the record rules list descriptions. This should include a "Action: " prefix for visual consistency. -->
+    <!-- Summary shown in the record rules list descriptions. This should include an "Action: " prefix for visual consistency. -->
     <string name="record_rule_action_discard_summary">Action: Discard recording</string>
-    <!-- Summary shown in the record rules list descriptions. This should include a "Action: " prefix for visual consistency. -->
+    <!-- Summary shown in the record rules list descriptions. This should include an "Action: " prefix for visual consistency. -->
     <string name="record_rule_action_ignore_summary">Action: Ignore call</string>
+
+    <!-- Title of the record rule editor section to configure whether the recording begins immediately or starts in the paused state. -->
+    <string name="record_rule_initial_state_title">Initial state</string>
+    <!-- Text for the UI chip to select this element in the rule editor. The text should be as short as possible. -->
+    <string name="record_rule_initial_state_recording_chip">Recording</string>
+    <!-- Text for the UI chip to select this element in the rule editor. The text should be as short as possible. -->
+    <string name="record_rule_initial_state_paused_chip">Paused</string>
+    <!-- Description shown for this action in the rule editor. The text can be as verbose as necessary. -->
+    <string name="record_rule_initial_state_recording_desc">The recording will begin immediately when the call connects.</string>
+    <!-- Description shown for this action in the rule editor. The text can be as verbose as necessary. -->
+    <string name="record_rule_initial_state_paused_desc">The recording will be paused when the call connects. Audio will not be recorded until the recording is resumed via the notification.</string>
+    <!-- Summary shown in the record rules list descriptions. This should include an "Initial state: " prefix for visual consistency. -->
+    <string name="record_rule_initial_state_recording_summary">Initial state: Record immediately</string>
+    <!-- Summary shown in the record rules list descriptions. This should include an "Initial state: " prefix for visual consistency. -->
+    <string name="record_rule_initial_state_paused_summary">Initial state: Paused until manually resumed</string>
 
     <!-- Output directory bottom sheet -->
     <string name="output_dir_bottom_sheet_change_dir">Change directory</string>


### PR DESCRIPTION
This is configurable via a new option in the record rules. This requires a migration of the stored preferences. Downgrading to previous versions will result in a crash until the app data is cleared due to strict JSON deserialization.

Closes: #853