### PR TITLE
Add mono and stereo suffixes to audio source labels

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/SettingsFragment.kt
@@ -161,7 +161,7 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
         val outputRetention = Retention.fromPreferences(prefs).toFormattedString(context)
 
         val summary = getString(R.string.pref_output_dir_desc)
-        prefOutputDir.summary = "${summary}\n\n${outputDirUri.formattedString} (${outputRetention})"
+        prefOutputDir.summary = "${summary}\n\n${outputDirUri.formattedString}, ${outputRetention}"
     }
 
     private fun refreshOutputFormat() {
@@ -173,7 +173,7 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
             append(getString(R.string.pref_output_format_desc))
             append("\n\n")
             append(savedFormat.format.name)
-            append(" (")
+            append(", ")
 
             when (val info = savedFormat.format.paramInfo) {
                 is RangedParamInfo -> {
@@ -187,8 +187,6 @@ class SettingsFragment : PreferenceBaseFragment(), Preference.OnPreferenceChange
             append(", ")
 
             append(getString(savedFormat.audioSource.nameResId))
-
-            append(")")
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,10 +221,10 @@
     <string name="format_sample_rate">%s Hz</string>
 
     <!-- Audio source -->
-    <string name="audio_source_voice_call">Combined</string>
-    <string name="audio_source_voice_uplink_downlink">Uplink + downlink</string>
-    <string name="audio_source_voice_uplink">Uplink only</string>
-    <string name="audio_source_voice_downlink">Downlink only</string>
+    <string name="audio_source_voice_call">Combined (Mono)</string>
+    <string name="audio_source_voice_uplink_downlink">Uplink + downlink (Stereo)</string>
+    <string name="audio_source_voice_uplink">Uplink only (Mono)</string>
+    <string name="audio_source_voice_downlink">Downlink only (Mono)</string>
     <string name="audio_source_stereo_warning">Very few devices support stereo recording. If recording fails or is missing audio, switch to a mono audio source.</string>
 
     <!-- Min duration dialog -->


### PR DESCRIPTION
Also removes parentheses in the output directory and output format summary strings on the main screen so that there would be duplicated parentheses with the new "(Mono)" and "(Stereo)" suffixes.

Co-Authored-By: @ElsAr4e