### PR TITLE
Make back navigation icon filled

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/bcr/ui/Screen.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -57,7 +59,12 @@ fun AppScreen(
                 title = title,
                 navigationIcon = {
                     onBack?.let { onClick ->
-                        IconButton(onClick = onClick) {
+                        IconButton(
+                            onClick = onClick,
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            ),
+                        ) {
                             @SuppressLint("PrivateResource")
                             Icon(
                                 imageVector = Icons.AutoMirrored.ArrowBack,


### PR DESCRIPTION
Matches Android SettingsLib's `settingslib_expressive_icon_back.xml` for Material 3 Expressive styling.