### PR TITLE
Fix startup crash when getExternalFilesDir() returns null

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -164,7 +164,14 @@ class Preferences(initialContext: Context) {
     val defaultOutputDir: File = if (isDirectBoot) {
         directBootInProgressDir
     } else {
-        context.getExternalFilesDir(null)!!
+        // [context] is backed by device-protected storage so preferences remain
+        // accessible during direct boot. However, getExternalFilesDir() can return
+        // null when invoked on a device-protected storage context (observed on some
+        // Android 16 builds), which made the !! here crash the app at startup. The
+        // external directory is only ever used once the user has unlocked the device,
+        // so query it from the original credential-protected context and fall back to
+        // internal storage if it is still unavailable.
+        initialContext.getExternalFilesDir(null) ?: directBootCompletedDir
     }
 
     /**


### PR DESCRIPTION
## Problem

On some devices BCR crashes immediately on launch:

```
java.lang.RuntimeException: Unable to create application com.chiller3.bcr.RecorderApplication
Caused by: java.lang.NullPointerException
    at com.chiller3.bcr.Preferences.<init>
    at com.chiller3.bcr.Notifications.<init>
    at com.chiller3.bcr.RecorderApplication.onCreate
```

## Cause

`Preferences` switches to a device-protected storage context so preferences stay readable during
direct boot, then computes `defaultOutputDir` with:

```kotlin
context.getExternalFilesDir(null)!!
```

`getExternalFilesDir()` is documented as nullable, and on a device-protected storage context it can
return `null`. This reproduces on an Android 16 build — external storage is mounted and works, only
the call on the device-protected context returns null — so the `!!` throws and the app can't start.
`isDirectBoot` is `false` at launch (user unlocked), so this is the normal code path.

## Fix

The external app directory is only used once the user has unlocked the device, so query it from the
original credential-protected context and fall back to the internal completed directory if it is
still unavailable:

```kotlin
initialContext.getExternalFilesDir(null) ?: directBootCompletedDir
```

Tested on-device (Android 16): BCR launches normally with the patch and crashes without it.

### Note

`outputDirOrDefaultIntent` does `defaultOutputDir.relativeTo(Environment.getExternalStorageDirectory())`.
If the internal fallback above is ever taken, that call would throw when opening the output folder with
no custom directory set. It isn't reached on devices where `getExternalFilesDir()` works (the common
case), so I kept it out of this change — happy to guard it with `relativeToOrNull` if you'd prefer.


P.S.: I reported this issue before, but I was ignored.