### PR TITLE
Prevent crash when changing output directory in direct boot

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -147,7 +147,7 @@ class Preferences(initialContext: Context) {
         set(enabled) = prefs.edit { putBoolean(PREF_FORCE_DIRECT_BOOT, enabled) }
 
     /** Whether we're running in direct boot mode. */
-    private val isDirectBoot: Boolean
+    val isDirectBoot: Boolean
         get() = !userManager.isUserUnlocked || forceDirectBoot
 
     /** Default output directory in the BFU state. */

--- a/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryScreen.kt
+++ b/app/src/main/java/com/chiller3/bcr/settings/OutputDirectoryScreen.kt
@@ -43,6 +43,11 @@ fun OutputDirectoryScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     val prefs = remember { Preferences(context) }
 
+    // The output directory is locked to internal device-protected storage while in direct boot, and
+    // Preferences.outputDir throws if it's changed in that state. Disable the picker/reset so the
+    // user can't trigger that crash (e.g. with the "force direct boot" debug option enabled).
+    val isDirectBoot = remember { prefs.isDirectBoot }
+
     var reloadPrefs by remember { mutableIntStateOf(0) }
     var outputDir by remember(reloadPrefs) { mutableStateOf(prefs.outputDirOrDefault) }
     var template by remember(reloadPrefs) {
@@ -61,7 +66,9 @@ fun OutputDirectoryScreen(onBack: () -> Unit) {
         title = { Text(text = stringResource(R.string.pref_output_dir_name)) },
         onBack = onBack,
         onReset = {
-            prefs.outputDir = null
+            if (!isDirectBoot) {
+                prefs.outputDir = null
+            }
             prefs.filenameTemplate = null
             prefs.outputRetention = null
             reloadPrefs++
@@ -71,12 +78,15 @@ fun OutputDirectoryScreen(onBack: () -> Unit) {
             outputDir = outputDir,
             template = template,
             retention = retention,
+            outputDirEnabled = !isDirectBoot,
             onOutputDirClick = {
                 requestSafOutputDir.launch(null)
             },
             onOutputDirReset = {
-                prefs.outputDir = null
-                reloadPrefs++
+                if (!isDirectBoot) {
+                    prefs.outputDir = null
+                    reloadPrefs++
+                }
             },
             onTemplateClick = { newTemplate ->
                 prefs.filenameTemplate = newTemplate
@@ -105,6 +115,7 @@ private fun OutputDirectoryContent(
     outputDir: Uri,
     template: Template,
     retention: Retention,
+    outputDirEnabled: Boolean,
     onOutputDirClick: () -> Unit,
     onOutputDirReset: () -> Unit,
     onTemplateClick: (Template) -> Unit,
@@ -128,6 +139,7 @@ private fun OutputDirectoryContent(
             Preference(
                 onClick = onOutputDirClick,
                 onLongClick = onOutputDirReset,
+                enabled = outputDirEnabled,
                 shapes = BetterSegmentedShapes.top(),
                 title = { Text(text = stringResource(R.string.pref_output_dir_name)) },
                 summary = { Text(text = outputDirFormatted) },
@@ -225,6 +237,7 @@ private fun PreviewOutputDirectoryScreen() {
                 outputDir = uri,
                 template = Preferences.DEFAULT_FILENAME_TEMPLATE,
                 retention = DaysRetention(365U),
+                outputDirEnabled = true,
                 onOutputDirClick = {},
                 onOutputDirReset = {},
                 onTemplateClick = {},


### PR DESCRIPTION
## Problem

`Preferences.outputDir`'s setter throws when assigned while in direct boot:

```kotlin
set(uri) {
    if (isDirectBoot) {
        throw IllegalStateException("Changing output directory while in direct boot")
    }
    ...
}
```

But `OutputDirectoryScreen` always enables the SAF directory picker and the reset actions. So with
the **Force direct boot** option enabled (`isDirectBoot` is then always true), picking a folder — or
resetting the output directory — crashes the app:

```
java.lang.IllegalStateException: Changing output directory while in direct boot
    at com.chiller3.bcr.Preferences.setOutputDir(Preferences.kt:203)
    at com.chiller3.bcr.settings.OutputDirectoryScreen…
    at androidx.activity.result.ActivityResultRegistry.doDispatch(…)
```

The screen-level reset (the toolbar reset) and the long-press reset both hit the same setter.

## Fix

Expose `isDirectBoot` and, when it's true:
- disable the output-directory `Preference` (the picker can't be launched), and
- skip the `outputDir` writes in the reset handlers.

The output directory is intentionally locked to internal device-protected storage during direct boot,
so this just stops the UI from attempting a change that can't be applied. The filename-template and
retention controls are untouched.
