### PR TITLE
gradle: Remove -Xannotation-default-target=param-property

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -179,12 +179,6 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xannotation-default-target=param-property")
-    }
-}
-
 androidComponents.onVariants { variant ->
     variant.sources.assets!!.addGeneratedSourceDirectory(archive) {
         project.objects.directoryProperty().apply {


### PR DESCRIPTION
It is no longer needed with Kotlin 2.4.