### PR TITLE
Mark the final Ogg page as the end of the stream

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/format/OggContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OggContainer.kt
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Django Eijgensteijn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package com.chiller3.bcr.format
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.system.Os
+import android.system.OsConstants
+import android.util.Log
+import com.chiller3.bcr.writeFully
+import java.io.FileDescriptor
+import java.io.IOException
+import java.nio.ByteBuffer
+
+/**
+ * [MediaMuxer] wrapper that marks the final Ogg page as the end of the logical bitstream.
+ *
+ * AOSP's Ogg muxer copies its `mReachedEOS` field into every packet's `e_o_s` field, but only sets
+ * that field to true after the last packet has already been written. As a result, no page in the
+ * output file ever has the end-of-stream bit set in its header type flags. Demuxers that seek to
+ * the end of the file to find the last granule position, like Firefox's, reject the file because
+ * the terminating page is missing.
+ *
+ * The fix is to set the bit in the last page's header after the muxer is done and recompute that
+ * page's CRC.
+ *
+ * @param fd Output file descriptor. This class does not take ownership of it and it should not be
+ * touched outside of this class until [stop] is called and returns.
+ */
+class OggContainer(private val fd: FileDescriptor) : Container {
+    private val muxer = MediaMuxer(fd, MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG)
+    private var isStarted = false
+    private var receivedEof = false
+
+    override fun start() {
+        if (isStarted) {
+            throw IllegalStateException("Container already started")
+        }
+
+        muxer.start()
+
+        isStarted = true
+    }
+
+    override fun stop() {
+        if (!isStarted) {
+            throw IllegalStateException("Container not started")
+        }
+
+        isStarted = false
+
+        // The muxer's writer thread closes its copy of the file descriptor when it stops, so the
+        // final page is only guaranteed to be on disk once this returns.
+        muxer.stop()
+
+        // An aborted recording has no final page to mark and the file may be truncated anywhere,
+        // so leave it alone rather than risk throwing over whatever error caused the abort.
+        if (receivedEof) {
+            setEndOfStreamFlag()
+        }
+    }
+
+    override fun release() {
+        try {
+            if (isStarted) {
+                stop()
+            }
+        } finally {
+            muxer.release()
+        }
+    }
+
+    override fun addTrack(mediaFormat: MediaFormat): Int =
+        muxer.addTrack(mediaFormat)
+
+    override fun writeSamples(trackIndex: Int, byteBuffer: ByteBuffer,
+                              bufferInfo: MediaCodec.BufferInfo) {
+        muxer.writeSampleData(trackIndex, byteBuffer, bufferInfo)
+
+        if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+            receivedEof = true
+        }
+    }
+
+    /**
+     * Set the end-of-stream bit in the header type flags of the file's last Ogg page and update
+     * that page's CRC checksum.
+     *
+     * @throws IOException If the last page cannot be found or cannot be read
+     */
+    private fun setEndOfStreamFlag() {
+        val fileSize = Os.lseek(fd, 0, OsConstants.SEEK_END)
+        val bufSize = minOf(fileSize, OggPage.MAX_SIZE.toLong()).toInt()
+        val buf = UByteArray(bufSize)
+
+        Os.lseek(fd, fileSize - bufSize, OsConstants.SEEK_SET)
+        if (Os.read(fd, buf.asByteArray(), 0, bufSize) != bufSize) {
+            throw IOException("EOF reached when reading final Ogg page")
+        }
+
+        val pageOffset = OggPage.findLast(buf)
+            ?: throw IOException("Final Ogg page not found")
+
+        if (!OggPage.markEndOfStream(buf, pageOffset)) {
+            Log.d(TAG, "Final Ogg page already marks the end of the stream")
+            return
+        }
+
+        Log.d(TAG, "Marked final Ogg page as the end of the stream")
+
+        Os.lseek(fd, fileSize - bufSize + pageOffset, OsConstants.SEEK_SET)
+        writeFully(fd, buf.asByteArray(), pageOffset, OggPage.headerSize(buf, pageOffset))
+    }
+
+    companion object {
+        private val TAG = OggContainer::class.java.simpleName
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/format/OggContainer.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OggContainer.kt
@@ -10,9 +10,11 @@ package com.chiller3.bcr.format
 import android.media.MediaCodec
 import android.media.MediaFormat
 import android.media.MediaMuxer
+import android.os.Build
 import android.system.Os
 import android.system.OsConstants
 import android.util.Log
+import androidx.annotation.RequiresApi
 import com.chiller3.bcr.writeFully
 import java.io.FileDescriptor
 import java.io.IOException
@@ -33,6 +35,7 @@ import java.nio.ByteBuffer
  * @param fd Output file descriptor. This class does not take ownership of it and it should not be
  * touched outside of this class until [stop] is called and returns.
  */
+@RequiresApi(Build.VERSION_CODES.Q)
 class OggContainer(private val fd: FileDescriptor) : Container {
     private val muxer = MediaMuxer(fd, MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG)
     private var isStarted = false

--- a/app/src/main/java/com/chiller3/bcr/format/OggPage.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OggPage.kt
@@ -1,0 +1,132 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Django Eijgensteijn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package com.chiller3.bcr.format
+
+import java.nio.ByteBuffer
+
+/**
+ * Ogg page structure, as much of it as is needed to terminate a bitstream.
+ *
+ * Kept free of Android dependencies so it can be unit tested on the JVM.
+ */
+object OggPage {
+    private val MAGIC = ubyteArrayOf(0x4fu, 0x67u, 0x67u, 0x53u) // OggS
+    private const val VERSION_OFFSET = 4
+    private const val HEADER_TYPE_OFFSET = 5
+    private const val CRC_OFFSET = 22
+    private const val CRC_SIZE = 4
+    private const val SEGMENT_COUNT_OFFSET = 26
+    private const val MAX_SEGMENT_COUNT = 255
+
+    const val MIN_HEADER_SIZE = 27
+
+    /** The largest an Ogg page can be: header, full segment table, and maximum body. */
+    const val MAX_SIZE = MIN_HEADER_SIZE + MAX_SEGMENT_COUNT + MAX_SEGMENT_COUNT * 255
+
+    private const val HEADER_TYPE_EOS: UByte = 0x04u
+
+    /** Ogg uses a non-reflected CRC-32 with no initial or final XOR value. */
+    private const val CRC_POLYNOMIAL = 0x04c11db7u
+
+    private val CRC_TABLE = UIntArray(256) { index ->
+        var value = index.toUInt().shl(24)
+
+        repeat(8) {
+            value = if (value and 0x80000000u != 0u) {
+                value.shl(1) xor CRC_POLYNOMIAL
+            } else {
+                value.shl(1)
+            }
+        }
+
+        value
+    }
+
+    /**
+     * Find the offset of the Ogg page that ends at the end of [buf].
+     *
+     * The search runs backwards because the buffer may begin in the middle of an earlier page. A
+     * candidate is only accepted if its segment table accounts for exactly the remaining bytes,
+     * which rules out the magic appearing inside page data.
+     */
+    fun findLast(buf: UByteArray): Int? {
+        for (offset in buf.size - MIN_HEADER_SIZE downTo 0) {
+            if (!buf.asByteArray().regionMatches(offset, MAGIC)) {
+                continue
+            }
+
+            if (buf[offset + VERSION_OFFSET] != 0.toUByte()) {
+                continue
+            }
+
+            val segmentCount = buf[offset + SEGMENT_COUNT_OFFSET].toInt()
+            val headerSize = MIN_HEADER_SIZE + segmentCount
+            if (offset + headerSize > buf.size) {
+                continue
+            }
+
+            var bodySize = 0
+            for (i in 0 until segmentCount) {
+                bodySize += buf[offset + MIN_HEADER_SIZE + i].toInt()
+            }
+
+            if (offset + headerSize + bodySize == buf.size) {
+                return offset
+            }
+        }
+
+        return null
+    }
+
+    /** Size of the page header at [offset], including its segment table. */
+    fun headerSize(buf: UByteArray, offset: Int): Int =
+        MIN_HEADER_SIZE + buf[offset + SEGMENT_COUNT_OFFSET].toInt()
+
+    fun isEndOfStream(buf: UByteArray, offset: Int): Boolean =
+        buf[offset + HEADER_TYPE_OFFSET] and HEADER_TYPE_EOS != 0.toUByte()
+
+    /**
+     * Set the end-of-stream bit in the header type flags of the page at [offset] and update its
+     * CRC checksum. The page must extend to the end of [buf].
+     *
+     * @return Whether the bit was set. False if the page already had it.
+     */
+    fun markEndOfStream(buf: UByteArray, offset: Int): Boolean {
+        if (isEndOfStream(buf, offset)) {
+            return false
+        }
+
+        buf[offset + HEADER_TYPE_OFFSET] = buf[offset + HEADER_TYPE_OFFSET] or HEADER_TYPE_EOS
+
+        // The checksum is computed with its own field zeroed out.
+        for (i in 0 until CRC_SIZE) {
+            buf[offset + CRC_OFFSET + i] = 0u
+        }
+
+        val crc = computeCrc(buf, offset, buf.size - offset)
+        for (i in 0 until CRC_SIZE) {
+            buf[offset + CRC_OFFSET + i] = (crc.shr(8 * i) and 0xffu).toUByte()
+        }
+
+        return true
+    }
+
+    private fun ByteArray.regionMatches(offset: Int, expected: UByteArray): Boolean =
+        ByteBuffer.wrap(this, offset, expected.size) == ByteBuffer.wrap(expected.asByteArray())
+
+    private fun computeCrc(buf: UByteArray, offset: Int, size: Int): UInt {
+        var crc = 0u
+
+        for (i in offset until offset + size) {
+            val index = (crc.shr(24) and 0xffu) xor buf[i].toUInt()
+            crc = crc.shl(8) xor CRC_TABLE[index.toInt()]
+        }
+
+        return crc
+    }
+}

--- a/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
@@ -50,6 +50,5 @@ class OpusFormat : Format() {
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    override fun getContainer(fd: FileDescriptor): Container =
-        OggContainer(fd)
+    override fun getContainer(fd: FileDescriptor): Container = OggContainer(fd)
 }

--- a/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
+++ b/app/src/main/java/com/chiller3/bcr/format/OpusFormat.kt
@@ -8,7 +8,6 @@
 package com.chiller3.bcr.format
 
 import android.media.MediaFormat
-import android.media.MediaMuxer
 import android.os.Build
 import androidx.annotation.RequiresApi
 import java.io.FileDescriptor
@@ -52,5 +51,5 @@ class OpusFormat : Format() {
 
     @RequiresApi(Build.VERSION_CODES.Q)
     override fun getContainer(fd: FileDescriptor): Container =
-        MediaMuxerContainer(fd, MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG)
+        OggContainer(fd)
 }

--- a/app/src/test/java/com/chiller3/bcr/format/OggPageTest.kt
+++ b/app/src/test/java/com/chiller3/bcr/format/OggPageTest.kt
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Django Eijgensteijn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+@file:OptIn(ExperimentalUnsignedTypes::class)
+
+package com.chiller3.bcr.format
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OggPageTest {
+    /**
+     * Build an Ogg page with [body] split into 255 byte segments.
+     *
+     * The CRC field is left zeroed. Callers that need a valid one go through
+     * [OggPage.markEndOfStream].
+     */
+    private fun page(headerType: Int, sequence: Int, body: UByteArray): UByteArray {
+        val segments = ArrayList<UByte>()
+        var remaining = body.size
+
+        while (remaining >= 255) {
+            segments.add(255u)
+            remaining -= 255
+        }
+        segments.add(remaining.toUByte())
+
+        val header = UByteArray(OggPage.MIN_HEADER_SIZE + segments.size)
+        "OggS".forEachIndexed { i, c -> header[i] = c.code.toUByte() }
+        header[4] = 0u
+        header[5] = headerType.toUByte()
+        // Granule position, serial number, and CRC are left as zero.
+        for (i in 0 until 4) {
+            header[18 + i] = (sequence.shr(8 * i) and 0xff).toUByte()
+        }
+        header[26] = segments.size.toUByte()
+        segments.forEachIndexed { i, s -> header[OggPage.MIN_HEADER_SIZE + i] = s }
+
+        return header + body
+    }
+
+    /**
+     * Reference CRC-32/MPEG-2 (non-reflected, zero init, no final XOR), computed bit by bit so it
+     * shares no code with the table driven implementation under test.
+     */
+    private fun referenceCrc(buf: UByteArray, offset: Int): UInt {
+        var crc = 0u
+
+        for (i in offset until buf.size) {
+            crc = crc xor buf[i].toUInt().shl(24)
+
+            repeat(8) {
+                crc = if (crc and 0x80000000u != 0u) {
+                    crc.shl(1) xor 0x04c11db7u
+                } else {
+                    crc.shl(1)
+                }
+            }
+        }
+
+        return crc
+    }
+
+    private fun crcField(buf: UByteArray, offset: Int): UInt {
+        var value = 0u
+
+        for (i in 0 until 4) {
+            value = value or buf[offset + 22 + i].toUInt().shl(8 * i)
+        }
+
+        return value
+    }
+
+    @Test
+    fun testFindLastPage() {
+        val buf = page(0x02, 0, UByteArray(10)) + page(0x00, 1, UByteArray(20))
+
+        assertEquals(OggPage.MIN_HEADER_SIZE + 1 + 10, OggPage.findLast(buf))
+    }
+
+    @Test
+    fun testFindLastPageIgnoresMagicInsideBody() {
+        // A page whose body happens to contain "OggS" followed by a plausible header.
+        val body = UByteArray(40)
+        val decoy = page(0x00, 9, UByteArray(4))
+        decoy.copyInto(body, 4, 0, minOf(decoy.size, body.size - 4))
+
+        val buf = page(0x02, 0, UByteArray(10)) + page(0x00, 1, body)
+
+        assertEquals(OggPage.MIN_HEADER_SIZE + 1 + 10, OggPage.findLast(buf))
+    }
+
+    @Test
+    fun testFindLastPageWithTruncatedBuffer() {
+        // A buffer that starts in the middle of a page has no page ending at its end.
+        val buf = page(0x00, 0, UByteArray(20)).copyOfRange(5, 20)
+
+        assertNull(OggPage.findLast(buf))
+    }
+
+    @Test
+    fun testFindLastPageRejectsUnknownVersion() {
+        val buf = page(0x00, 0, UByteArray(10))
+        buf[4] = 1u
+
+        assertNull(OggPage.findLast(buf))
+    }
+
+    @Test
+    fun testMarkEndOfStreamSetsFlagAndCrc() {
+        val buf = page(0x00, 1, ubyteArrayOf(1u, 2u, 3u, 4u, 5u))
+        val offset = OggPage.findLast(buf)!!
+
+        assertFalse(OggPage.isEndOfStream(buf, offset))
+        assertTrue(OggPage.markEndOfStream(buf, offset))
+
+        assertTrue(OggPage.isEndOfStream(buf, offset))
+        assertEquals(0x04u.toUByte(), buf[offset + 5])
+
+        // The stored CRC must match a from-scratch computation over the whole page.
+        val expected = run {
+            val zeroed = buf.copyOf()
+            for (i in 0 until 4) {
+                zeroed[offset + 22 + i] = 0u
+            }
+            referenceCrc(zeroed, offset)
+        }
+
+        assertEquals(expected, crcField(buf, offset))
+    }
+
+    @Test
+    fun testMarkEndOfStreamPreservesEverythingElse() {
+        val body = UByteArray(300) { (it and 0xff).toUByte() }
+        val buf = page(0x00, 7, body)
+        val before = buf.copyOf()
+        val offset = OggPage.findLast(buf)!!
+
+        assertTrue(OggPage.markEndOfStream(buf, offset))
+
+        // Only the header type byte and the CRC field may change.
+        assertArrayEquals(
+            before.copyOfRange(0, offset + 5).asByteArray(),
+            buf.copyOfRange(0, offset + 5).asByteArray(),
+        )
+        assertArrayEquals(
+            before.copyOfRange(offset + 6, offset + 22).asByteArray(),
+            buf.copyOfRange(offset + 6, offset + 22).asByteArray(),
+        )
+        assertArrayEquals(
+            before.copyOfRange(offset + 26, before.size).asByteArray(),
+            buf.copyOfRange(offset + 26, buf.size).asByteArray(),
+        )
+    }
+
+    @Test
+    fun testMarkEndOfStreamIsNoOpWhenAlreadySet() {
+        val buf = page(0x04, 1, ubyteArrayOf(1u, 2u, 3u))
+        val offset = OggPage.findLast(buf)!!
+        val before = buf.copyOf()
+
+        assertFalse(OggPage.markEndOfStream(buf, offset))
+        assertArrayEquals(before.asByteArray(), buf.asByteArray())
+    }
+
+    @Test
+    fun testHeaderSizeIncludesSegmentTable() {
+        // 300 bytes of body needs two segment table entries: 255 and 45.
+        val buf = page(0x00, 1, UByteArray(300))
+        val offset = OggPage.findLast(buf)!!
+
+        assertEquals(OggPage.MIN_HEADER_SIZE + 2, OggPage.headerSize(buf, offset))
+    }
+
+    @Test
+    fun testMaxSizeMatchesOggLimit() {
+        assertEquals(65307, OggPage.MAX_SIZE)
+    }
+}


### PR DESCRIPTION
**TL;DR:** BCR's `.oga` recordings are missing the marker that says "this is where the file ends". Most players do not care, but stricter ones refuse to play the file at all, and in Firefox none of them work. This adds the marker when a recording finishes. Nothing about the audio itself changes, and existing recordings are unaffected.


**Technical version**

The OGG/Opus files BCR writes never terminate the logical bitstream: no page in the output has the end-of-stream bit set in its header type flags. The Ogg spec requires the last page of a stream to carry that bit, so every `.oga` recording BCR has produced is malformed.

The cause is in AOSP's `OggWriter`. It sets each packet's flag from its own member inside the write loop:

```cpp
op.e_o_s = mReachedEOS ? 1 : 0;
```

but `mReachedEOS` only becomes true at the end of `threadFunc()`, after the loop has finished. It is false for every packet actually written, and neither `stop()` nor `reset()` writes a terminating page afterwards.

`OggContainer` wraps `MediaMuxer` and, once it has stopped, sets the bit in the last page's header and recomputes that page's CRC. Audio data is untouched. Like `FlacContainer`, this is a finalization step guarded on encoder EOF, so aborted recordings behave exactly as they do today.

The practical benefit is that demuxers which seek to the end of the file to find the last granule position will accept the recordings. Firefox is one, and currently refuses to play them with `NS_ERROR_DOM_MEDIA_METADATA_ERR`.

The page and CRC logic lives in `OggPage`, free of Android dependencies so it can be unit tested on the JVM. `OggPageTest` covers the backwards page search, the `OggS` magic appearing inside page data, the flag and CRC update, and that nothing outside the header type byte and CRC field is touched. The CRC is checked against a bit-by-bit reference implementation that shares no code with the table driven one.

`assembleDebug` and the unit tests pass.