### PR TITLE
gradle: Remove redundant File object construction

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -540,7 +540,7 @@ fun updateChangelog(version: String?, replaceFirst: Boolean) {
 }
 
 fun updateMagiskChangelog(gitRef: String) {
-    File(File(File(File(projectDir, "magisk"), "updates"), "release"), "changelog.txt")
+    File(projectDir, "magisk/updates/release/changelog.txt")
         .writeText("The changelog can be found at: [`CHANGELOG.md`]($projectUrl/blob/$gitRef/CHANGELOG.md).\n")
 }
 


### PR DESCRIPTION
The `File` constructor normalizes slashes in the child path component anyway.