### PR TITLE
Improve notification when persisted URI permission is lost

### DIFF
--- a/app/src/main/java/com/chiller3/bcr/Notifications.kt
+++ b/app/src/main/java/com/chiller3/bcr/Notifications.kt
@@ -395,7 +395,7 @@ class Notifications(
     }
 
     /** Send a file move failure alert notification. */
-    fun notifyMoveFailure(errorMsg: String?) {
+    fun notifyMoveFailure(exception: Exception) {
         val notificationId = prefs.nextNotificationId
 
         val notification = Notification.Builder(context, CHANNEL_ID_FAILURE).run {
@@ -404,7 +404,12 @@ class Notifications(
             setContentText(buildString {
                 append(context.getString(R.string.notification_move_error))
 
-                errorMsg?.trim()?.let {
+                val details = if (exception is RecorderThread.LostOutputDirPermissionsException) {
+                    context.getString(R.string.notification_move_error_permissions)
+                } else {
+                    exception.localizedMessage?.trim()
+                }
+                details?.let {
                     append("\n\n")
                     append(it)
                 }

--- a/app/src/main/java/com/chiller3/bcr/Preferences.kt
+++ b/app/src/main/java/com/chiller3/bcr/Preferences.kt
@@ -233,6 +233,14 @@ class Preferences(initialContext: Context) {
             Notifications(context).dismissAll()
         }
 
+    fun hasOutputDirPermissions(): Boolean {
+        val outputDir = outputDir ?: return true
+
+        return context.contentResolver.persistedUriPermissions.any {
+            it.uri == outputDir && it.isReadPermission && it.isWritePermission
+        }
+    }
+
     /**
      * Get the user-specified output directory or the default if none was set. This method does not
      * perform any filesystem operations to check if the user-specified directory is still valid.

--- a/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderInCallService.kt
@@ -475,7 +475,7 @@ class RecorderInCallService : InCallService(), RecorderThread.OnRecordingComplet
             val firstMoveError = file?.moveError
                 ?: additionalFiles.firstNotNullOfOrNull { it.moveError }
             if (firstMoveError != null) {
-                notifications.notifyMoveFailure(firstMoveError.localizedMessage)
+                notifications.notifyMoveFailure(firstMoveError)
             }
 
             when (status) {

--- a/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
+++ b/app/src/main/java/com/chiller3/bcr/RecorderThread.kt
@@ -299,7 +299,11 @@ class RecorderThread(
                             )
                             outputDocPath = finalPath
                         } catch (e: Exception) {
-                            moveError = e
+                            moveError = if (prefs.hasOutputDirPermissions()) {
+                                e
+                            } else {
+                                LostOutputDirPermissionsException(e)
+                            }
                         }
 
                         writeMetadataFile(finalPath.value, recordingInfo)?.let {
@@ -929,6 +933,9 @@ class RecorderThread(
 
     private class PureSilenceException(cause: Throwable? = null)
         : Exception("Audio contained pure silence", cause)
+
+    class LostOutputDirPermissionsException(cause: Throwable? = null)
+        : Exception("Lost permissions to output directory", cause)
 
     sealed interface FailureComponent {
         data class AndroidMedia(val stackFrame: StackTraceElement) : FailureComponent

--- a/app/src/main/java/com/chiller3/bcr/extension/DocumentFileExtensions.kt
+++ b/app/src/main/java/com/chiller3/bcr/extension/DocumentFileExtensions.kt
@@ -184,6 +184,28 @@ fun DocumentFile.findOrCreateDirectories(path: List<String>): DocumentFile? {
     return file
 }
 
+/** Like [DocumentFile.name], but does not eat the exception. */
+private val DocumentFile.nameWithException: String
+    get() = when (uri.scheme) {
+        ContentResolver.SCHEME_CONTENT -> {
+            val cursor = context!!.contentResolver.query(
+                uri,
+                arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+                null, null, null,
+            ) ?: throw IOException("Query returned null cursor: $uri")
+
+            cursor.use {
+                if (cursor.moveToFirst() && !cursor.isNull(0)) {
+                    return cursor.getString(0)
+                }
+            }
+
+            throw IOException("Cursor returned no display name: $uri")
+        }
+        // This leaves only RawDocumentFile, which never returns null.
+        else -> name!!
+    }
+
 /**
  * This is a horrible workaround to reduce the chance of an Android bug. Sometimes, when making
  * DocumentsContract calls, com.android.externalstorage will be frozen according to:
@@ -201,14 +223,21 @@ fun DocumentFile.findOrCreateDirectories(path: List<String>): DocumentFile? {
  * This just repeatedly tries to talk to com.android.externalstorage to try and get it out of the
  * frozen state.
  */
-fun DocumentFile.workAroundBinderBug() {
+private fun DocumentFile.workAroundBinderBug() {
     Log.d(TAG, "Working around Android binder bug")
     val deadline = System.nanoTime() + 2_000_000_000L
 
     while (System.nanoTime() < deadline) {
-        if (name != null) {
-            Log.d(TAG, "Got binder response")
+        try {
+            val name = nameWithException
+            Log.d(TAG, "Got binder response: $name")
             return
+        } catch (e: SecurityException) {
+            // This is going to fail forever if we lost access to the directory.
+            Log.d(TAG, "Skipping workaround due to losing access to URI: $uri", e)
+            return
+        } catch (_: Exception) {
+            // Ignore.
         }
 
         Thread.sleep(100)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="notification_recording_succeeded">Successfully recorded call</string>
     <string name="notification_move_failed">Failed to move recording</string>
     <string name="notification_move_error">One or more files could not be moved to the selected output directory. They are still present in the default output directory.</string>
+    <string name="notification_move_error_permissions">This was caused by Android revoking BCR\'s existing permissions to the directory. Selecting the same output directory will grant the required permissions again.</string>
     <string name="notification_message_delete_at_end">The recording will be deleted at the end of the call. Tap Restore to keep the recording.</string>
     <plurals name="notification_message_delete_at_end_too_short">
         <item quantity="one">The recording will be deleted at the end of the call if it is shorter than %d second. Tap Restore to keep the recording.</item>


### PR DESCRIPTION
The "Failed to move recording" notification will now tell the user to reselect the output directory instead of just dumping the raw exception message if BCR's persisted URI permissions were revoked.

Issue: #919